### PR TITLE
add _build from docs build guide to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ docs/Makefile
 PYPI_VERSION
 build/
 wheelhouse/
+_build/


### PR DESCRIPTION
Small change to make sure generated docs are not added to the project

Note that the build guide for the docs in the PGM is different (https://power-grid-model.readthedocs.io/en/stable/advanced_documentation/build-guide.html#documentation) differs from the one in this project (https://github.com/PowerGridModel/power-grid-model-ds/blob/main/docs/source/advanced_documentation/build_guide.md) but there is no Makefile for the docs in this project yet.