### PR TITLE
docs: rename dependency group

### DIFF
--- a/docs/advanced_documentation/build_guide.md
+++ b/docs/advanced_documentation/build_guide.md
@@ -37,7 +37,7 @@ pytest
 
 To build the documentation locally execute the following commands
 ```
-pip install -e .[docs]
+pip install -e .[doc]
 
 # build the docs
 cd docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dev = [
   "pre-commit>=4",
 
 ]
-docs = [
+doc = [
   "sphinx",
   "myst-nb",
   "sphinx_rtd_theme",


### PR DESCRIPTION
Renames doc dependencies to match PGM (and readthedocs.yaml)