### PR TITLE
Drop python 3.10

### DIFF
--- a/.github/workflows/build-test-and-sonar.yml
+++ b/.github/workflows/build-test-and-sonar.yml
@@ -104,7 +104,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ["3.10", "3.11", "3.12", "3.13"]
+        python: ["3.11", "3.12", "3.13"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
   "Operating System :: MacOS",
   "Topic :: Scientific/Engineering :: Physics",
 ]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.14"
 dependencies = ["power-grid-model>=1.7", "rustworkx>= 0.15.1", "numpy>=1.21"]
 dynamic = ["version"]
 


### PR DESCRIPTION
Let's not merge until all open source pgm-related packages are ready to drop python 3.10.

Relates to https://github.com/PowerGridModel/.github/pull/47
Relates to https://github.com/PowerGridModel/power-grid-model/pull/879
Relates to https://github.com/PowerGridModel/power-grid-model-io/pull/288