### PR TITLE
chore: remove unused/nonfunctional cache on graphcontainer

### DIFF
--- a/src/power_grid_model_ds/_core/model/graphs/container.py
+++ b/src/power_grid_model_ds/_core/model/graphs/container.py
@@ -6,7 +6,6 @@
 
 import dataclasses
 from dataclasses import dataclass
-from pathlib import PosixPath
 from typing import Generator
 
 import numpy as np
@@ -118,15 +117,6 @@ class GraphContainer:
             if graph.active_only:
                 graph.delete_branch(from_ext_node_id=from_node, to_ext_node_id=to_node)
             setattr(self, field.name, graph)
-
-    def cache(self, cache_dir: PosixPath, compress: bool) -> PosixPath:
-        """Cache the container into a folder with .pkl and graph files"""
-        cache_dir.mkdir(parents=True, exist_ok=True)
-
-        for field in self.graph_attributes:
-            graph = getattr(self, field.name)
-            graph.cache(cache_dir=cache_dir, graph_name=field.name, compress=compress)
-        return cache_dir
 
     @classmethod
     def from_arrays(cls, arrays: MinimalGridArrays) -> "GraphContainer":


### PR DESCRIPTION
The `GraphContainer` still had a `cache` method, but we do not implement `cache` on `GraphModel` anymore. Instead when caching the grid, we just cache the arrays and with `from_cache` we restore the graph using `from_arrays`. 

https://github.com/PowerGridModel/power-grid-model-ds/blob/00a7d2dcc4b8732efd1bf46d9915fc94b1c338e9/src/power_grid_model_ds/_core/model/grids/base.py#L387-L402