### PR TITLE
Fix: re-order publish steps so artifact isn't deleted by checkout step

### DIFF
--- a/.github/workflows/build-test-and-sonar.yml
+++ b/.github/workflows/build-test-and-sonar.yml
@@ -141,6 +141,10 @@ jobs:
       TWINE_PASSWORD: ${{ secrets.PYPI_PASS }}
     runs-on: ubuntu-latest
     steps:
+
+      - name: Checkout source code
+        uses: actions/checkout@v4  # needed by 'Prevent automatic major/minor release'
+
       - name: Setup Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -151,10 +155,6 @@ jobs:
         with:
           name: power-grid-model-ds
           path: wheelhouse/
-
-      - name: Checkout source code
-        if: (github.event_name == 'push')
-        uses: actions/checkout@v4  # needed by 'Prevent automatic major/minor release'
 
       - name: Prevent automatic major/minor release
         if: (github.event_name == 'push')


### PR DESCRIPTION
It seems that `actions/checkout@v4` resets the working directory and thus deletes `wheelhouse/`. I expect that re-ordering the steps will fix the issue.