### PR TITLE
Fix: prevent type change when using tmp_remove_nodes

### DIFF
--- a/src/power_grid_model_ds/_core/model/graphs/models/base.py
+++ b/src/power_grid_model_ds/_core/model/graphs/models/base.py
@@ -208,7 +208,7 @@ class BaseGraphModel(ABC):
         yield
 
         for node in nodes:
-            self.add_node(node)
+            self.add_node(int(node))  # convert to int to avoid type issues when input is e.g. a numpy array
         for source, target in edge_list:
             self.add_branch(source, target)
 

--- a/src/power_grid_model_ds/_core/model/grids/helpers.py
+++ b/src/power_grid_model_ds/_core/model/grids/helpers.py
@@ -46,7 +46,7 @@ def set_feeder_ids(grid: "Grid"):
     """
     _reset_feeder_ids(grid)
     feeder_node_ids = grid.node.filter(node_type=NodeType.SUBSTATION_NODE)["id"]
-    with grid.graphs.active_graph.tmp_remove_nodes(feeder_node_ids):
+    with grid.graphs.active_graph.tmp_remove_nodes(feeder_node_ids.tolist()):
         components = grid.graphs.active_graph.get_components()
     for component_node_ids in components:
         component_branches = _get_active_component_branches(grid, component_node_ids)

--- a/tests/unit/model/graphs/test_graph_model.py
+++ b/tests/unit/model/graphs/test_graph_model.py
@@ -171,6 +171,14 @@ def test_tmp_remove_nodes(graph_with_2_routes: BaseGraphModel) -> None:
     assert counter_before == counter_after
 
 
+def test_tmp_remove_nodes_array_input(graph_with_2_routes: BaseGraphModel) -> None:
+    with graph_with_2_routes.tmp_remove_nodes(np.array([1, 2])):  # type: ignore[arg-type]
+        pass
+
+    # check that the external ids are still all integers instead of e.g. np.int
+    assert all([isinstance(e_id, int) for e_id in graph_with_2_routes.external_ids])
+
+
 def test_get_components(graph_with_2_routes: BaseGraphModel):
     graph = graph_with_2_routes
     graph.add_node(99)


### PR DESCRIPTION
Found was an issue where the graph.external_ids would change type if the input to graph.tmp_remove_nodes is an ndarray[int[ instead of a list[int]

While a type-checker should prevent you from doing this. It is not enforced at runtime.
This PR prevents the type change by explicitly casting the ids to integers before re-adding them to the graph.

Example:
```python
    with graph.tmp_remove_nodes(np.array([1, 2])): 
        pass
# would previously result in graph.external_ids to contain np.int values instead of int values
```


