### PR TITLE
Fix typing issue for numpy 2.3 and python 3.11

### DIFF
--- a/src/power_grid_model_ds/_core/model/arrays/base/_filters.py
+++ b/src/power_grid_model_ds/_core/model/arrays/base/_filters.py
@@ -20,7 +20,7 @@ def get_filter_mask(
     """Returns a mask that matches the input parameters."""
     parsed_kwargs = _parse(args, kwargs)
 
-    if invalid_kwargs := set(parsed_kwargs.keys()) - set(array.dtype.names):
+    if invalid_kwargs := set(parsed_kwargs.keys()) - set(array.dtype.names or ()):
         raise ValueError(f"Invalid kwargs: {invalid_kwargs}")
 
     filter_mask = _initialize_filter_mask(mode_, array.size)

--- a/src/power_grid_model_ds/_core/model/arrays/base/_modify.py
+++ b/src/power_grid_model_ds/_core/model/arrays/base/_modify.py
@@ -12,7 +12,7 @@ def re_order(array: np.ndarray, new_order: ArrayLike, column: str = "id") -> np.
     """Re-order an id-array by the id column so that it follows a new_order.
     Expects the new_order input to contain the same values as self.id
     """
-    if column not in array.dtype.names:
+    if column not in (array.dtype.names or ()):
         raise ValueError(f"Cannot re-order array: column {column} does not exist.")
     if not np.array_equal(np.sort(array[column]), np.sort(new_order)):
         raise ValueError(f"Cannot re-order array: mismatch between new_order and values in '{column}'-column.")
@@ -50,7 +50,7 @@ def update_by_id(array: np.ndarray, ids: ArrayLike, allow_missing: bool, **kwarg
 
 def check_ids(array: np.ndarray, return_duplicates: bool = False) -> NDArray | None:
     """Check for duplicate ids within the array"""
-    if "id" not in array.dtype.names:
+    if "id" not in (array.dtype.names or ()):
         raise AttributeError("Array has no 'id' column.")
 
     unique, counts = np.unique(array["id"], return_counts=True)


### PR DESCRIPTION
Seems related to a numpy release. In any case, these errors have been showing up recently:

On python 3.12, mypy thinks it's fine, but on python 3.11 these show up..

```
src/power_grid_model_ds/_core/model/arrays/base/_modify.py:15: error: Unsupported right operand type for in ("tuple[str, ...] | None")  [operator]
src/power_grid_model_ds/_core/model/arrays/base/_modify.py:53: error: Unsupported right operand type for in ("tuple[str, ...] | None")  [operator]
src/power_grid_model_ds/_core/model/arrays/base/_filters.py:23: error: Argument 1 to "set" has incompatible type "tuple[str, ...] | None"; expected "Iterable[str]"  [arg-type]
src/power_grid_model_ds/_core/model/arrays/base/_filters.py:23: error: Argument 1 to "set" has incompatible type "tuple[str, ...] | None"; expected "Iterable[Any | None]"  [arg-type]
src/power_grid_model_ds/_core/model/arrays/base/_build.py:28: error: Argument 1 to "_check_missing_columns" has incompatible type "tuple[str, ...] | None"; expected "tuple[Any, ...]"  [arg-type]
src/power_grid_model_ds/_core/model/arrays/base/_build.py:34: error: Argument 1 to "_check_missing_columns" has incompatible type "tuple[str, ...] | None"; expected "tuple[Any, ...]"  [arg-type]
src/power_grid_model_ds/_core/model/arrays/base/_build.py:67: error: Argument 1 to "empty" has incompatible type "dtype[Any]"; expected "type"  [arg-type]
src/power_grid_model_ds/_core/model/arrays/base/_build.py:67: note: Error code "arg-type" not covered by "type: ignore" comment
src/power_grid_model_ds/_core/model/arrays/base/_build.py:90: error: Argument 1 to "set" has incompatible type "tuple[str, ...] | None"; expected "Iterable[str]"  [arg-type]
src/power_grid_model_ds/_core/model/arrays/base/_build.py:91: error: Argument 1 to "set" has incompatible type "tuple[str, ...] | None"; expected "Iterable[str]"  [arg-type]

```

