### PR TITLE
TypeError: BaseGraphModel.get_components() got an unexpected keyword argument 'substation_nodes'

### DIFF
--- a/docs/examples/model/generator_examples.ipynb
+++ b/docs/examples/model/generator_examples.ipynb
@@ -1,0 +1,359 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# RadialGridGenerator Examples\n",
+    "\n",
+    "The `RadialGridGenerator` class in the `power_grid_model_ds` library is designed to generate radial grid structures with nodes, sources, lines, and optionally transformers. This documentation covers the usage of the `RadialGridGenerator` class, including grid generation, node, source, and line generation, and various grid configuration functions.\n",
+    "\n",
+    "## Grid Generation\n",
+    "\n",
+    "### Generating a Random Grid\n",
+    "\n",
+    "The `RadialGridGenerator` class can be used to generate a random grid with a specified structure. The `run` method initializes the grid generation process.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of nodes: 102\n",
+      "Number of sources: 2\n",
+      "Number of loads: 100\n"
+     ]
+    }
+   ],
+   "source": [
+    "from power_grid_model_ds import Grid\n",
+    "from power_grid_model_ds.generators import RadialGridGenerator\n",
+    "\n",
+    "# Generate a random grid\n",
+    "grid_generator = RadialGridGenerator(grid_class=Grid)\n",
+    "grid = grid_generator.run(seed=0)\n",
+    "\n",
+    "# Verify the structure of the generated grid\n",
+    "print(f\"Number of nodes: {len(grid.node)}\")\n",
+    "print(f\"Number of sources: {len(grid.source)}\")\n",
+    "print(f\"Number of loads: {len(grid.sym_load)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Generating a Random Grid with Transformers\n",
+    "\n",
+    "The RadialGridGenerator can also generate a grid that includes transformers.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of transformers: 2\n"
+     ]
+    }
+   ],
+   "source": [
+    "from power_grid_model_ds import Grid\n",
+    "from power_grid_model_ds.generators import RadialGridGenerator\n",
+    "\n",
+    "# Generate a random grid with transformers\n",
+    "grid_generator = RadialGridGenerator(grid_class=Grid)\n",
+    "grid = grid_generator.run(seed=0, create_10_3_kv_net=True)\n",
+    "\n",
+    "# Verify the transformers in the generated grid\n",
+    "print(f\"Number of transformers: {len(grid.transformer)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Node Generation\n",
+    "\n",
+    "The NodeGenerator class is used to generate random nodes within the grid.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generated nodes: \n",
+      " id | u_rated | node_type | feeder_branch_id | feeder_node_id \n",
+      " 1  | 10500.0 |     0     |        0         |       0        \n",
+      " 2  | 10500.0 |     0     |        0         |       0        \n",
+      "Low load scenarios: \n",
+      " id | node | status | type | p_specified | q_specified \n",
+      " 3  |  1   |   1    |  0   |   218860.0  |   29606.0   \n",
+      " 4  |  2   |   1    |  0   |   180184.0  |   21574.0   \n",
+      "High load scenarios: \n",
+      " id | node | status | type | p_specified | q_specified \n",
+      " 5  |  1   |   1    |  0   |  -287484.0  |   40640.0   \n",
+      " 6  |  2   |   1    |  0   |   26558.0   |   28148.0   \n"
+     ]
+    }
+   ],
+   "source": [
+    "from power_grid_model_ds import Grid\n",
+    "from power_grid_model_ds.arrays import NodeArray\n",
+    "from power_grid_model_ds.generators import NodeGenerator\n",
+    "\n",
+    "# Generate random nodes\n",
+    "grid = Grid.empty()\n",
+    "node_generator = NodeGenerator(grid, seed=0)\n",
+    "nodes, loads_low, loads_high = node_generator.run(amount=2)\n",
+    "\n",
+    "# Verify the generated nodes and loads\n",
+    "print(f\"Generated nodes: \\n{nodes}\")\n",
+    "print(f\"Low load scenarios: \\n{loads_low}\")\n",
+    "print(f\"High load scenarios: \\n{loads_high}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source Generation\n",
+    "\n",
+    "The SourceGenerator class is used to generate random sources within the grid.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generated nodes: \n",
+      " id | u_rated | node_type | feeder_branch_id | feeder_node_id \n",
+      " 1  | 10500.0 |     1     |   -2147483648    |  -2147483648   \n",
+      "Generated sources: \n",
+      " id | node | status | u_ref \n",
+      " 2  |  1   |   1    |  1.0  \n"
+     ]
+    }
+   ],
+   "source": [
+    "from power_grid_model_ds import Grid\n",
+    "from power_grid_model_ds.arrays import SourceArray\n",
+    "from power_grid_model_ds.generators import SourceGenerator\n",
+    "\n",
+    "# Generate random sources\n",
+    "grid = Grid.empty()\n",
+    "source_generator = SourceGenerator(grid=grid, seed=0)\n",
+    "nodes, sources = source_generator.run(amount=1)\n",
+    "\n",
+    "# Verify the generated nodes and sources\n",
+    "print(f\"Generated nodes: \\n{nodes}\")\n",
+    "print(f\"Generated sources: \\n{sources}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Line Generation\n",
+    "\n",
+    "The LineGenerator class is used to generate random lines within the grid.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generated lines: \n",
+      " id | from_node | to_node | from_status | to_status | feeder_branch_id | feeder_node_id | is_feeder |   r1  |   x1  |  c1 | tan1 |   i_n   \n",
+      " 5  |     0     |    3    |      1      |     1     |        0         |       0        |   False   |0.003..|4.538..| 0.0 | 0.0  |303.919..\n",
+      " 6  |     0     |    2    |      1      |     1     |        0         |       0        |   False   |0.134..|0.015..| 0.0 | 0.0  |425.988..\n",
+      " 7  |     3     |    1    |      1      |     1     |        0         |       0        |   False   |1.211..|0.065..| 0.0 | 0.0  |663.357..\n",
+      " 8  |     0     |    2    |      1      |     0     |        0         |       0        |   False   |0.629..|0.006..| 0.0 | 0.0  |313.880..\n",
+      " 9  |     3     |    2    |      1      |     0     |        0         |       0        |   False   |0.070..|0.029..| 0.0 | 0.0  |269.786..\n"
+     ]
+    }
+   ],
+   "source": [
+    "from power_grid_model_ds import Grid\n",
+    "from power_grid_model_ds.generators import LineGenerator\n",
+    "\n",
+    "# Setup initial nodes and sources\n",
+    "grid = Grid.empty()\n",
+    "nodes = NodeArray.zeros(4)\n",
+    "nodes.id = [0, 1, 2, 3]\n",
+    "nodes.u_rated = [10_500] * 4\n",
+    "\n",
+    "sources = SourceArray.zeros(1)\n",
+    "sources.id = [4]\n",
+    "sources.node = [0]\n",
+    "sources.status = [1]\n",
+    "sources.u_ref = [1]\n",
+    "\n",
+    "grid.append(nodes)\n",
+    "grid.append(sources)\n",
+    "\n",
+    "# Generate random lines\n",
+    "line_generator = LineGenerator(grid=grid, seed=0)\n",
+    "lines = line_generator.run(amount=2)\n",
+    "\n",
+    "# Verify the generated lines\n",
+    "print(f\"Generated lines: \\n{lines}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Grid Configuration Functions\n",
+    "\n",
+    "### Creating Routes\n",
+    "\n",
+    "The create_routes method in the LineGenerator class generates routes between nodes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generated routes: \n",
+      " id | from_node | to_node | from_status | to_status | feeder_branch_id | feeder_node_id | is_feeder |   r1  |   x1  |  c1 | tan1 |  i_n   \n",
+      " 5  |     0     |    3    |      1      |     1     |        0         |       0        |   False   |0.347..|0.008..| 0.0 | 0.0  |306.03..\n",
+      " 6  |     0     |    1    |      1      |     1     |        0         |       0        |   False   |0.082..|0.037..| 0.0 | 0.0  |254.90..\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create routes\n",
+    "line_generator.create_routes(2)\n",
+    "\n",
+    "# Verify the generated routes\n",
+    "print(f\"Generated routes: \\n{line_generator.line_array}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Connecting Nodes\n",
+    "\n",
+    "The connect_nodes method connects unconnected nodes in the grid.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Connected nodes: [0, 1, 3]\n",
+      "Unconnected nodes: [2]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Connect unconnected nodes\n",
+    "line_generator.set_unconnected_nodes()\n",
+    "line_generator.connect_nodes()\n",
+    "\n",
+    "# Verify the connected nodes\n",
+    "print(f\"Connected nodes: {line_generator.connected_nodes}\")\n",
+    "print(f\"Unconnected nodes: {line_generator.unconnected_nodes}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Creating Normally Open Points\n",
+    "\n",
+    "The create_nop_lines method generates normally open points in the grid.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generated NOP lines: \n",
+      " id | from_node | to_node | from_status | to_status | feeder_branch_id | feeder_node_id | is_feeder |   r1  |   x1  |  c1 | tan1 |   i_n   \n",
+      " 5  |     0     |    3    |      1      |     1     |        0         |       0        |   False   |0.347..|0.008..| 0.0 | 0.0  |306.039..\n",
+      " 6  |     0     |    1    |      1      |     1     |        0         |       0        |   False   |0.082..|0.037..| 0.0 | 0.0  |254.909..\n",
+      " 7  |     0     |    2    |      1      |     1     |        0         |       0        |   False   |0.064..|0.004..| 0.0 | 0.0  |445.042..\n",
+      " 8  |     1     |    2    |      1      |     0     |        0         |       0        |   False   |0.209..|0.024..| 0.0 | 0.0  |270.937..\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create normally open points\n",
+    "line_generator.create_nop_lines(1)\n",
+    "\n",
+    "# Verify the generated normally open points\n",
+    "print(f\"Generated NOP lines: \\n{line_generator.line_array}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
**Fixes issue**: `TypeError: BaseGraphModel.get_components() got an unexpected keyword argument 'substation_nodes'`

### Changes proposed in this PR include:

---> 44 components = graph.get_components(substation_nodes=substation_nodes)
     45 print(f"Connected components: {components}")
     47 # Getting nodes connected to node 1, exclusive of node 1

TypeError: BaseGraphModel.get_components() got an unexpected keyword argument 'substation_nodes'

-->

components = graph.get_components()
print(f"Connected components: {components}")

# Then, find the component that contains our substation from the list of all components.
# This allows us to find the specific component that includes the first element from `substation_nodes`.
substation_node_id = substation_nodes[0]
connected_component = next(c for c in components if substation_node_id in c)
print(f"Component connected to the substation: {connected_component}")
