### PR TITLE
Fix link colors in visualizer

### DIFF
--- a/src/power_grid_model_ds/_core/visualizer/layout/colors.py
+++ b/src/power_grid_model_ds/_core/visualizer/layout/colors.py
@@ -5,11 +5,12 @@
 YELLOW = "#facc37"
 CYTO_COLORS = {
     "line": YELLOW,
-    "link": "green",
+    "link": "#008000",
     "transformer": "#4290f5",
     "node": YELLOW,
     "selected": "#e28743",
     "selected_transformer": "#0349a3",
+    "selected_link": "#004000",
     "substation_node": "purple",
     "open_branch": "#c9c9c9",
     "highlighted": "#a10000",

--- a/src/power_grid_model_ds/_core/visualizer/layout/cytoscape_styling.py
+++ b/src/power_grid_model_ds/_core/visualizer/layout/cytoscape_styling.py
@@ -75,6 +75,16 @@ _SELECTED_TRANSFORMER_STYLE = {
     },
 }
 
+_LINK_STYLE = {
+    "selector": "edge[group = 'link']",
+    "style": {"line-color": CYTO_COLORS["link"], "target-arrow-color": CYTO_COLORS["link"]},
+}
+
+_SELECTED_LINK_STYLE = {
+    "selector": "edge[group = 'link']:selected, edge[group = 'link']:active",
+    "style": {"line-color": CYTO_COLORS["selected_link"], "target-arrow-color": CYTO_COLORS["selected_link"]},
+}
+
 _OPEN_BRANCH_STYLE = {
     "selector": "edge[from_status = 0], edge[to_status = 0]",
     "style": {
@@ -106,9 +116,11 @@ DEFAULT_STYLESHEET = [
     _SUBSTATION_NODE_STYLE,
     _BRANCH_STYLE,
     _TRANSFORMER_STYLE,
+    _LINK_STYLE,
     _SELECTED_NODE_STYLE,
     _SELECTED_BRANCH_STYLE,
     _SELECTED_TRANSFORMER_STYLE,
+    _SELECTED_LINK_STYLE,
     _OPEN_BRANCH_STYLE,
     _OPEN_FROM_SIDE_BRANCH_STYLE,
     _OPEN_TO_SIDE_BRANCH_STYLE,

--- a/tests/integration/visualizer_tests.py
+++ b/tests/integration/visualizer_tests.py
@@ -29,6 +29,11 @@ def get_coordinated_grid() -> CoordinatedGrid:
     return grid
 
 
+def get_grid_with_links() -> Grid:
+    grid = Grid.from_txt("S1 2 transformer", "2 3 link", "3 4")
+    return grid
+
+
 def visualize_grid():
     visualize(grid=get_radial_grid(), debug=True)
 
@@ -40,6 +45,11 @@ def visualize_coordinated_grid():
     )
 
 
+def visualize_grid_with_links():
+    visualize(grid=get_grid_with_links(), debug=True)
+
+
 if __name__ == "__main__":
     visualize_grid()
     # visualize_coordinated_grid()
+    # visualize_grid_with_links()


### PR DESCRIPTION
**Fixes issue**: Links were not marked GREEN, but remained YELLOW instead.

This PR fixes that by extending the cytoscape stylesheet

<img width="354" height="260" alt="Screenshot 2025-10-08 at 00 10 33" src="https://github.com/user-attachments/assets/88625f9f-c9f7-4878-ac21-9cadb9124e7b" />

