### PR TITLE
Add type overload for __getitem__

### DIFF
--- a/src/power_grid_model_ds/_core/model/arrays/base/array.py
+++ b/src/power_grid_model_ds/_core/model/arrays/base/array.py
@@ -6,7 +6,7 @@ from abc import ABC
 from collections import namedtuple
 from copy import copy
 from functools import lru_cache
-from typing import Any, Iterable, Literal, Type, TypeVar
+from typing import Any, Iterable, Literal, Type, TypeVar, overload
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -152,7 +152,12 @@ class FancyArray(ABC):
         except (AttributeError, ValueError) as error:
             raise AttributeError(f"Cannot set attribute {attr} on {self.__class__.__name__}") from error
 
-    def __getitem__(self: Self, item):
+    @overload
+    def __getitem__(self: Self, item: str | list | tuple) -> NDArray[Any]: ...
+    @overload
+    def __getitem__(self: Self, item: Any) -> Self: ...
+
+    def __getitem__(self, item):
         """Used by for-loops, slicing [0:3], column-access ['id'], row-access [0], multi-column access.
         Note: If a single item is requested, return a named tuple instead of a np.void object.
         """


### PR DESCRIPTION
In projects that use power-grid-model-ds as a dependency, I noticed that the type inferred by `pyright` when using e.g.`node_array['id']` is `NodeArray`, whereas `NDArray[int]` is expected.

This change seems to fix that, while I don't really understand why:

Reason I don't fully understand it:

If I change
```python
    @overload
    def __getitem__(self: Self, item: str | list | tuple) -> NDArray[Any]: ...
```
to:
```python
    @overload
    def __getitem__(self: Self, item: str | list | tuple) -> None: ...
```
(or any other output type)

then:
`pyright` is also happy...

Also in both cases (with and without this PR)
`reveal_type(node['id'])` results in np.ndarray 

Seems strange to me...

