### PR TITLE
Update __eq__ so it is a bit stricter

### DIFF
--- a/src/power_grid_model_ds/_core/model/arrays/base/array.py
+++ b/src/power_grid_model_ds/_core/model/arrays/base/array.py
@@ -332,4 +332,4 @@ class FancyArray(ABC):
         if not isinstance(extended, cls):
             raise TypeError(f"Extended array must be of type {cls.__name__}, got {type(extended).__name__}")
         dtype = cls.get_dtype()
-        return cls(data=np.array(extended.data[list(dtype.names)], dtype=dtype))
+        return cls(data=np.array(extended[list(dtype.names)], dtype=dtype))


### PR DESCRIPTION
See title.

piggyback: fix typing warning from pyright - warning: TypeVar "Self" appears only once in generic function signature
After reading this: https://github.com/microsoft/pyright/discussions/2755, I think it is better to remove Self typehints when it's only used once