### PR TITLE
Add type hints to GraphModel properties and fix documentation

### DIFF
--- a/src/power_grid_model_ds/_core/model/graphs/models/base.py
+++ b/src/power_grid_model_ds/_core/model/graphs/models/base.py
@@ -29,12 +29,12 @@ class BaseGraphModel(ABC):
 
     @property
     @abstractmethod
-    def nr_nodes(self):
+    def nr_nodes(self) -> int:
         """Returns the number of nodes in the graph"""
 
     @property
     @abstractmethod
-    def nr_branches(self):
+    def nr_branches(self) -> int:
         """Returns the number of branches in the graph"""
 
     @property
@@ -251,7 +251,7 @@ class BaseGraphModel(ABC):
         return [self._internals_to_externals(path) for path in internal_paths]
 
     def get_components(self) -> list[list[int]]:
-        """Returns all separate components when the substation_nodes are removed of the graph as lists
+        """Returns all separate components of the graph as lists
 
         If you want to get the components of the graph without certain nodes,
         use the `tmp_remove_nodes` context manager.

--- a/src/power_grid_model_ds/_core/model/graphs/models/rustworkx.py
+++ b/src/power_grid_model_ds/_core/model/graphs/models/rustworkx.py
@@ -26,11 +26,11 @@ class RustworkxGraphModel(BaseGraphModel):
         self._external_to_internal: dict[int, int] = {}
 
     @property
-    def nr_nodes(self):
+    def nr_nodes(self) -> int:
         return self._graph.num_nodes()
 
     @property
-    def nr_branches(self):
+    def nr_branches(self) -> int:
         return self._graph.num_edges()
 
     @property


### PR DESCRIPTION
### Changes proposed in this PR include:

> Here you can elaborate on the chosen solution strategy, which changes did you make and which goal do they serve. Perhaps also which things are you still unsure of.

- Add type hints to nr_nodes and nr_branches properties of GraphModels
- Fix incorrect documentation for BaseGraphModel.get_components()

### Could you please pay extra attention to the points below when reviewing the PR:

- -

### Checks

- [ ] If changes are related to CI/CD, are they verified via a manual run on this branch?
