### PR TITLE
Fix issues with public auto-imports in IDEs

### DIFF
--- a/src/power_grid_model_ds/__init__.py
+++ b/src/power_grid_model_ds/__init__.py
@@ -2,8 +2,21 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
+from power_grid_model_ds import arrays, constants, enums, errors, fancypy, generators, graph_models, visualizer
 from power_grid_model_ds._core.load_flow import PowerGridModelInterface
 from power_grid_model_ds._core.model.graphs.container import GraphContainer
 from power_grid_model_ds._core.model.grids.base import Grid
 
-__all__ = ["Grid", "GraphContainer", "PowerGridModelInterface"]
+__all__ = [
+    "Grid",
+    "GraphContainer",
+    "PowerGridModelInterface",
+    "arrays",
+    "constants",
+    "enums",
+    "errors",
+    "fancypy",
+    "generators",
+    "graph_models",
+    "visualizer",
+]


### PR DESCRIPTION
When power-grid-model-ds is installed as a dependency in a project, IDEs like Pycharm and VSCode had trouble auto-importing modules not specified in `__init__.__all__`.

This should solve the issue