### PR TITLE
Avoid empty input arrays

### DIFF
--- a/src/power_grid_model_ds/_core/power_grid_model_interface.py
+++ b/src/power_grid_model_ds/_core/power_grid_model_interface.py
@@ -55,11 +55,13 @@ class PowerGridModelInterface:
         """
         Create input for the PowerGridModel
         """
+        self._input_data = {}
         for array_name in ComponentType:
             if not hasattr(self.grid, array_name):
                 continue
             pgm_array = self._create_power_grid_array(array_name=array_name)
-            self._input_data[array_name] = pgm_array
+            if pgm_array.size > 0:
+                self._input_data[array_name] = pgm_array
         return self._input_data
 
     def create_grid_from_input_data(self, check_ids: bool = True) -> Grid:

--- a/tests/unit/model/grids/serialization/test_json.py
+++ b/tests/unit/model/grids/serialization/test_json.py
@@ -115,12 +115,9 @@ class TestSerializationRoundtrips:
         loaded_grid = Grid.deserialize(path)
         assert loaded_grid == grid
 
-    @pytest.mark.parametrize("grid_fixture", ("basic_grid", "grid"))
-    def test_pgm_roundtrip(self, request, grid_fixture: str, tmp_path: Path):
+    def test_pgm_roundtrip(self, basic_grid: Grid, tmp_path: Path):
         """Test roundtrip serialization for PGM-compatible grid"""
-        # Grid
-        grid: Grid = request.getfixturevalue(grid_fixture)
-
+        grid = basic_grid
         # Replace nan values with dummy value. Otherwise PGM's json_serialize_to_file will remove these columns.
         grid.node.u_rated = 42
 


### PR DESCRIPTION
When converting to a pgm_input_dict, we should not include empty arrays.

Reasons:
- It doesn't add value
- Keeps the input_dict as small as possible
- ~~PGM's validate_input_data does not seem to support empty arrays.~~
  - ~~There is something else going on. I want to investigate once #176 is merged~~
  - Should be supported but there is a bug https://github.com/PowerGridModel/power-grid-model/issues/1319

Note: As @mgovers suggested, this is technically a breaking change (different set of dict keys in pgm_input dict). Though I doubt it will have much impact.