### PR TITLE
feat: move from dash table to dash ag grid

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ visualizer = [
   "dash>=3.0.0",
   "dash-bootstrap-components>=2.0.0",
   "dash-cytoscape>=1.0.2",
+  "dash-ag-grid",
 ]
 pandas = ["pandas>=2.2.1"]
 
@@ -59,6 +60,7 @@ dev = [
   "dash>=3.0.0",
   "dash-bootstrap-components>=2.0.0",
   "dash-cytoscape>=1.0.2",
+  "dash-ag-grid",
   "nb-clean>=4.0.1",
 ]
 

--- a/src/power_grid_model_ds/_core/visualizer/callbacks/element_selection.py
+++ b/src/power_grid_model_ds/_core/visualizer/callbacks/element_selection.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 
-import logging
 from typing import Any
 
 import dash_ag_grid as dag
@@ -16,8 +15,6 @@ from power_grid_model_ds._core.visualizer.layout.selection_output import (
 from power_grid_model_ds._core.visualizer.parsing_utils import viz_id_to_pgm_id
 from power_grid_model_ds._core.visualizer.server_state import get_grid
 from power_grid_model_ds.arrays import IdArray
-
-_logger = logging.getLogger(__name__)
 
 
 @callback(

--- a/src/power_grid_model_ds/_core/visualizer/callbacks/element_selection.py
+++ b/src/power_grid_model_ds/_core/visualizer/callbacks/element_selection.py
@@ -45,12 +45,7 @@ def display_selected_element(node_data: list[dict[str, Any]], edge_data: list[di
 
 
 def _to_data_table(array_data: IdArray):
-    data_table_headers: list[dict[str, str]] = []
-    for col in array_data.columns:
-        if array_data[col].ndim == 1:
-            data_table_headers.append({"field": col, "headerName": col})
-        else:
-            _logger.warning("Column '%s' is not 1-dimensional hence not visualized.", col)
+    data_table_headers: list[dict[str, str]] = [{"field": col, "headerName": col} for col in array_data.columns]
 
     list_array_data = []
     for entry in array_data:
@@ -58,6 +53,8 @@ def _to_data_table(array_data: IdArray):
         for col in array_data.columns:
             if entry[col].ndim == 1:
                 record_dict[col] = entry[col].item()
+            else:
+                record_dict[col] = entry[col].tolist().pop()
 
         list_array_data.append(record_dict)
 

--- a/src/power_grid_model_ds/_core/visualizer/callbacks/element_selection.py
+++ b/src/power_grid_model_ds/_core/visualizer/callbacks/element_selection.py
@@ -19,6 +19,7 @@ from power_grid_model_ds.arrays import IdArray
 
 _logger = logging.getLogger(__name__)
 
+
 @callback(
     Output("selection-output", "children"),
     Input("cytoscape-graph", "selectedNodeData"),

--- a/src/power_grid_model_ds/_core/visualizer/callbacks/element_selection.py
+++ b/src/power_grid_model_ds/_core/visualizer/callbacks/element_selection.py
@@ -3,9 +3,11 @@
 # SPDX-License-Identifier: MPL-2.0
 
 
+import logging
 from typing import Any
 
-from dash import Input, Output, callback, dash_table
+import dash_ag_grid as dag
+from dash import Input, Output, callback
 
 from power_grid_model_ds._core.model.grids.base import Grid
 from power_grid_model_ds._core.visualizer.layout.selection_output import (
@@ -15,6 +17,7 @@ from power_grid_model_ds._core.visualizer.parsing_utils import viz_id_to_pgm_id
 from power_grid_model_ds._core.visualizer.server_state import get_grid
 from power_grid_model_ds.arrays import IdArray
 
+_logger = logging.getLogger(__name__)
 
 @callback(
     Output("selection-output", "children"),
@@ -41,14 +44,27 @@ def display_selected_element(node_data: list[dict[str, Any]], edge_data: list[di
 
 
 def _to_data_table(array_data: IdArray):
-    array_data_dict = {}
-    for column in array_data.columns:
-        array_data_dict[column] = array_data[column].item()
+    data_table_headers: list[dict[str, str]] = []
+    for col in array_data.columns:
+        if array_data[col].ndim == 1:
+            data_table_headers.append({"field": col, "headerName": col})
+        else:
+            _logger.warning("Column '%s' is not 1-dimensional hence not visualized.", col)
+
+    list_array_data = []
+    for entry in array_data:
+        record_dict = {}
+        for col in array_data.columns:
+            if entry[col].ndim == 1:
+                record_dict[col] = entry[col].item()
+
+        list_array_data.append(record_dict)
 
     # ignore[attr-defined] added for https://github.com/plotly/dash/issues/3226
-    return dash_table.DataTable(  # type: ignore[attr-defined]
-        data=[array_data_dict],
-        columns=[{"name": key, "id": key} for key in array_data_dict],
-        editable=False,
-        fill_width=False,
+    return dag.AgGrid(  # type: ignore[attr-defined]
+        rowData=list_array_data,
+        columnDefs=data_table_headers,
+        defaultColDef={"filter": True},
+        dashGridOptions={"maintainColumnOrder": True, "animateRows": False},
+        columnSize="sizeToFit",
     )

--- a/tests/integration/visualizer_tests.py
+++ b/tests/integration/visualizer_tests.py
@@ -5,16 +5,24 @@
 
 from dataclasses import dataclass
 
+import numpy as np
+
 from power_grid_model_ds import Grid
-from power_grid_model_ds.arrays import SourceArray
+from power_grid_model_ds._core.model.dtypes.typing import NDArray3
+from power_grid_model_ds.arrays import LineArray, SourceArray
 from power_grid_model_ds.generators import RadialGridGenerator
 from power_grid_model_ds.visualizer import visualize
 from tests.unit.visualizer.test_parsers import CoordinatedNodeArray
 
 
+class ThreePhaseCoordinatedLineArray(LineArray):
+    three_phase_quantity: NDArray3[np.float64]
+
+
 @dataclass
-class CoordinatedGrid(Grid):
+class ThreePhaseCoordinatedGrid(Grid):
     node: CoordinatedNodeArray
+    line: ThreePhaseCoordinatedLineArray
 
 
 def get_radial_grid() -> Grid:
@@ -23,9 +31,11 @@ def get_radial_grid() -> Grid:
     return grid
 
 
-def get_coordinated_grid() -> CoordinatedGrid:
+def get_coordinated_three_phase_grid() -> ThreePhaseCoordinatedGrid:
     scale = 500
-    grid = CoordinatedGrid.from_txt("S1 2 open", "2 3", "3 4", "S1 500000000", "500000000 6", "6 7 transformer,open")
+    grid = ThreePhaseCoordinatedGrid.from_txt(
+        "S1 2 open", "2 3", "3 4", "S1 500000000", "500000000 6", "6 7 transformer,open"
+    )
 
     source = SourceArray.empty(1)
     source.node = 1
@@ -34,6 +44,7 @@ def get_coordinated_grid() -> CoordinatedGrid:
     grid.node.x *= scale
     grid.node.y = [3, 4, 3, 4, 3, 4, 3]
     grid.node.y *= scale
+    grid.line.three_phase_quantity = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12], [np.nan, np.nan, np.nan]])
     return grid
 
 
@@ -46,9 +57,9 @@ def visualize_grid():
     visualize(grid=grid, debug=True)
 
 
-def visualize_coordinated_grid():
+def visualize_coordinated_three_phase_grid():
     visualize(
-        grid=get_coordinated_grid(),
+        grid=get_coordinated_three_phase_grid(),
         debug=True,
     )
 
@@ -81,7 +92,7 @@ def visualize_grid_with_all_open_types():
 
 if __name__ == "__main__":
     # visualize_grid()
-    # visualize_coordinated_grid()
+    # visualize_coordinated_three_phase_grid()
     # visualize_grid_with_links()
     # visualize_grid_with_all_types()
     visualize_grid_with_all_open_types()

--- a/tests/unit/visualizer/test_callbacks.py
+++ b/tests/unit/visualizer/test_callbacks.py
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
+import dash_ag_grid as dag
 import pytest
-from dash import dash_table
 from dash.exceptions import PreventUpdate
 
 from power_grid_model_ds._core.model.grids.base import Grid
@@ -83,21 +83,20 @@ def test_element_selection_callback():
     edge_data = []
 
     result = display_selected_element(node_data, edge_data)
-    expected = dash_table.DataTable(  # type: ignore[attr-defined]
-        data=[
+    expected = dag.AgGrid(  # type: ignore[attr-defined]
+        rowData=[
             {"u_rated": 100.0, "id": 1, "node_type": 0, "feeder_branch_id": -2147483648, "feeder_node_id": -2147483648}
         ],
-        columns=[
-            {"name": "id", "id": "id"},
-            {"name": "u_rated", "id": "u_rated"},
-            {"name": "node_type", "id": "node_type"},
-            {"name": "feeder_branch_id", "id": "feeder_branch_id"},
-            {"name": "feeder_node_id", "id": "feeder_node_id"},
+        columnDefs=[
+            {"field": "id", "headerName": "id"},
+            {"field": "u_rated", "headerName": "u_rated"},
+            {"field": "node_type", "headerName": "node_type"},
+            {"field": "feeder_branch_id", "headerName": "feeder_branch_id"},
+            {"field": "feeder_node_id", "headerName": "feeder_node_id"},
         ],
-        editable=False,
     )
-    assert result.data == expected.data
-    assert result.columns == expected.columns
+    assert result.rowData == expected.rowData
+    assert result.columnDefs == expected.columnDefs
 
 
 def test_display_selected_element_none():

--- a/tests/unit/visualizer/test_callbacks.py
+++ b/tests/unit/visualizer/test_callbacks.py
@@ -3,9 +3,11 @@
 # SPDX-License-Identifier: MPL-2.0
 
 import dash_ag_grid as dag
+import numpy as np
 import pytest
 from dash.exceptions import PreventUpdate
 
+from power_grid_model_ds._core.model.dtypes.typing import NDArray3
 from power_grid_model_ds._core.model.grids.base import Grid
 from power_grid_model_ds._core.visualizer import server_state
 from power_grid_model_ds._core.visualizer.callbacks.config import scale_elements, update_arrows, update_layout
@@ -16,6 +18,14 @@ from power_grid_model_ds._core.visualizer.layout.selection_output import SELECTI
 from power_grid_model_ds.arrays import NodeArray
 
 _EDGE_INDEX = 3
+
+
+class ThreePhaseNodeArray(NodeArray):
+    three_phase_quantity: NDArray3[np.float64]
+
+
+class ThreePhaseGrid(Grid):
+    node: ThreePhaseNodeArray
 
 
 def test_scale_elements():
@@ -72,10 +82,11 @@ def test_hide_arrows():
 
 
 def test_element_selection_callback():
-    grid = Grid.empty()
-    grid.node = NodeArray.empty(1)
+    grid = ThreePhaseGrid.empty()
+    grid.node = ThreePhaseNodeArray.empty(1)
     grid.node.id = [1]
     grid.node.u_rated = [100.0]
+    grid.node.three_phase_quantity = [[1.0, 2.0, 3.0]]
 
     server_state.set_grid(grid)
 
@@ -85,7 +96,14 @@ def test_element_selection_callback():
     result = display_selected_element(node_data, edge_data)
     expected = dag.AgGrid(  # type: ignore[attr-defined]
         rowData=[
-            {"u_rated": 100.0, "id": 1, "node_type": 0, "feeder_branch_id": -2147483648, "feeder_node_id": -2147483648}
+            {
+                "u_rated": 100.0,
+                "id": 1,
+                "node_type": 0,
+                "feeder_branch_id": -2147483648,
+                "feeder_node_id": -2147483648,
+                "three_phase_quantity": [1.0, 2.0, 3.0],
+            }
         ],
         columnDefs=[
             {"field": "id", "headerName": "id"},
@@ -93,6 +111,7 @@ def test_element_selection_callback():
             {"field": "node_type", "headerName": "node_type"},
             {"field": "feeder_branch_id", "headerName": "feeder_branch_id"},
             {"field": "feeder_node_id", "headerName": "feeder_node_id"},
+            {"field": "three_phase_quantity", "headerName": "three_phase_quantity"},
         ],
     )
     assert result.rowData == expected.rowData

--- a/uv.lock
+++ b/uv.lock
@@ -356,6 +356,18 @@ wheels = [
 ]
 
 [[package]]
+name = "dash-ag-grid"
+version = "35.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/4d/259d21112a087a23ecd2f7dd651412755bf0547835805c38f3c77c971052/dash_ag_grid-35.2.0.tar.gz", hash = "sha256:507f5dccf7235bf1b9af2c59d4cd0f12205db03c3489f605948f13c72bcece4f", size = 5794514, upload-time = "2026-04-03T10:46:26.05Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/71/7f97793a3449ee5218f0fb820c03c15be11a7c6d0c61c37d38779b753d4e/dash_ag_grid-35.2.0-py3-none-any.whl", hash = "sha256:b8b33780faa7322101b0559658da2a301a58a3329ff6a2c45f1490f0c3719df9", size = 5836952, upload-time = "2026-04-03T10:46:23.957Z" },
+]
+
+[[package]]
 name = "dash-bootstrap-components"
 version = "2.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -486,6 +498,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -494,6 +507,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -502,6 +516,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
     { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
     { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
     { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
     { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
     { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
@@ -510,6 +525,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
     { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
     { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
     { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
@@ -1313,6 +1329,7 @@ pandas = [
 ]
 visualizer = [
     { name = "dash" },
+    { name = "dash-ag-grid" },
     { name = "dash-bootstrap-components" },
     { name = "dash-cytoscape" },
 ]
@@ -1321,6 +1338,7 @@ visualizer = [
 dev = [
     { name = "coverage" },
     { name = "dash" },
+    { name = "dash-ag-grid" },
     { name = "dash-bootstrap-components" },
     { name = "dash-cytoscape" },
     { name = "mypy" },
@@ -1343,6 +1361,7 @@ doc = [
 [package.metadata]
 requires-dist = [
     { name = "dash", marker = "extra == 'visualizer'", specifier = ">=3.0.0" },
+    { name = "dash-ag-grid", marker = "extra == 'visualizer'" },
     { name = "dash-bootstrap-components", marker = "extra == 'visualizer'", specifier = ">=2.0.0" },
     { name = "dash-cytoscape", marker = "extra == 'visualizer'", specifier = ">=1.0.2" },
     { name = "numpy", specifier = ">=2.0" },
@@ -1356,6 +1375,7 @@ provides-extras = ["visualizer", "pandas"]
 dev = [
     { name = "coverage" },
     { name = "dash", specifier = ">=3.0.0" },
+    { name = "dash-ag-grid" },
     { name = "dash-bootstrap-components", specifier = ">=2.0.0" },
     { name = "dash-cytoscape", specifier = ">=1.0.2" },
     { name = "mypy" },


### PR DESCRIPTION
The dash table will indeed be deprecated: https://dash.plotly.com/datatable
Best to address before the visualizer PRs.