### PR TITLE
Add explicit size property to FancyArray

### DIFF
--- a/src/power_grid_model_ds/_core/model/arrays/base/array.py
+++ b/src/power_grid_model_ds/_core/model/arrays/base/array.py
@@ -273,6 +273,10 @@ class FancyArray(ABC):  # noqa: B024
             return tpl_cls(*self._data)
         return tpl_cls(*self._data[0])
 
+    @property
+    def size(self) -> int:
+        return self._data.size
+
     def filter(
         self: Self,
         *args: int | Iterable[int] | np.ndarray,

--- a/tests/unit/model/arrays/test_array.py
+++ b/tests/unit/model/arrays/test_array.py
@@ -318,5 +318,6 @@ def test_from_extended_array():
     array_equal_with_nan(array.data, extended_array[array.columns])
 
 
+
 def test_size(fancy_test_array: FancyTestArray):
     assert fancy_test_array.size == 3

--- a/tests/unit/model/arrays/test_array.py
+++ b/tests/unit/model/arrays/test_array.py
@@ -316,3 +316,7 @@ def test_from_extended_array():
     array = LineArray.from_extended(extended_array)
     assert not isinstance(array, DefaultedCustomLineArray)
     array_equal_with_nan(array.data, extended_array[array.columns])
+
+
+def test_size(fancy_test_array: FancyTestArray):
+    assert fancy_test_array.size == 3

--- a/tests/unit/model/arrays/test_array.py
+++ b/tests/unit/model/arrays/test_array.py
@@ -317,5 +317,6 @@ def test_from_extended_array():
     assert not isinstance(array, DefaultedCustomLineArray)
     array_equal_with_nan(array.data, extended_array[array.columns])
 
+
 def test_size(fancy_test_array: FancyTestArray):
     assert fancy_test_array.size == 3

--- a/tests/unit/model/arrays/test_array.py
+++ b/tests/unit/model/arrays/test_array.py
@@ -317,6 +317,5 @@ def test_from_extended_array():
     assert not isinstance(array, DefaultedCustomLineArray)
     array_equal_with_nan(array.data, extended_array[array.columns])
 
-
 def test_size(fancy_test_array: FancyTestArray):
     assert fancy_test_array.size == 3

--- a/tests/unit/model/arrays/test_array.py
+++ b/tests/unit/model/arrays/test_array.py
@@ -318,6 +318,5 @@ def test_from_extended_array():
     array_equal_with_nan(array.data, extended_array[array.columns])
 
 
-
 def test_size(fancy_test_array: FancyTestArray):
     assert fancy_test_array.size == 3


### PR DESCRIPTION
Fixes #221 

### Changes proposed in this PR include:


- Add the size property explicitly to the FancyArray class, so that static type checkers can infer the property type


### Could you please pay extra attention to the points below when reviewing the PR:

- Not sure what the testing strategy is for the repo, but I added a simple test to ensure .size works

