### PR TITLE
feat: rewrite get_inherited_attrs (id-columns part 1/2)

### DIFF
--- a/src/power_grid_model_ds/_core/model/arrays/base/array.py
+++ b/src/power_grid_model_ds/_core/model/arrays/base/array.py
@@ -52,6 +52,7 @@ class FancyArray(ABC):  # noqa: B024
     Note on string-columns:
         The default length for string columns is stored in _DEFAULT_STR_LENGTH.
         To change this, you can set the _str_lengths class attribute.
+        The _str_lengths attribute is inherited by child classes.
 
     Example:
         >>> class MyArray(FancyArray):

--- a/src/power_grid_model_ds/_core/model/arrays/base/array.py
+++ b/src/power_grid_model_ds/_core/model/arrays/base/array.py
@@ -19,7 +19,11 @@ from power_grid_model_ds._core.model.arrays.base._optional import pd
 from power_grid_model_ds._core.model.arrays.base._string import convert_array_to_string
 from power_grid_model_ds._core.model.arrays.base.errors import ArrayDefinitionError
 from power_grid_model_ds._core.model.constants import EMPTY_ID, empty
-from power_grid_model_ds._core.utils.misc import array_equal_with_nan, build_mro_attribute, get_public_annotations
+from power_grid_model_ds._core.utils.misc import (
+    array_equal_with_nan,
+    combine_attribute_from_parent_classes,
+    get_public_annotations,
+)
 
 # pylint: disable=missing-function-docstring, too-many-public-methods
 
@@ -80,13 +84,13 @@ class FancyArray(ABC):  # noqa: B024
     @classmethod
     @lru_cache
     def get_defaults(cls) -> dict[str, Any]:
-        return build_mro_attribute(cls, "_defaults", attribute_type=dict)
+        return combine_attribute_from_parent_classes(cls, "_defaults", attribute_type=dict)
 
     @classmethod
     @lru_cache
     def get_dtype(cls):
         annotations = get_public_annotations(cls)
-        str_lengths = build_mro_attribute(cls, "_str_lengths", dict)
+        str_lengths = combine_attribute_from_parent_classes(cls, "_str_lengths", dict)
         dtypes = {}
         for name, dtype in annotations.items():
             if len(dtype.__args__) > 1:

--- a/src/power_grid_model_ds/_core/model/arrays/base/array.py
+++ b/src/power_grid_model_ds/_core/model/arrays/base/array.py
@@ -65,7 +65,6 @@ class FancyArray(ABC):  # noqa: B024
     _data: NDArray = np.ndarray([])
     _defaults: ClassVar[dict[str, Any]] = {}
     _str_lengths: ClassVar[dict[str, int]] = {}
-    _id_columns: ClassVar[set[str]] = set()
 
     def __init__(self, *args, data: NDArray | None = None, **kwargs):
         if data is None:

--- a/src/power_grid_model_ds/_core/model/arrays/base/array.py
+++ b/src/power_grid_model_ds/_core/model/arrays/base/array.py
@@ -19,7 +19,7 @@ from power_grid_model_ds._core.model.arrays.base._optional import pd
 from power_grid_model_ds._core.model.arrays.base._string import convert_array_to_string
 from power_grid_model_ds._core.model.arrays.base.errors import ArrayDefinitionError
 from power_grid_model_ds._core.model.constants import EMPTY_ID, empty
-from power_grid_model_ds._core.utils.misc import array_equal_with_nan, get_public_class_attrs, build_mro_attribute
+from power_grid_model_ds._core.utils.misc import array_equal_with_nan, build_mro_attribute, get_public_annotations
 
 # pylint: disable=missing-function-docstring, too-many-public-methods
 
@@ -90,7 +90,7 @@ class FancyArray(ABC):  # noqa: B024
     @classmethod
     @lru_cache
     def get_dtype(cls):
-        annotations = get_public_class_attrs(cls)
+        annotations = get_public_annotations(cls)
         str_lengths = build_mro_attribute(cls, "_str_lengths", dict)
         dtypes = {}
         for name, dtype in annotations.items():

--- a/src/power_grid_model_ds/_core/model/arrays/base/array.py
+++ b/src/power_grid_model_ds/_core/model/arrays/base/array.py
@@ -53,11 +53,6 @@ class FancyArray(ABC):  # noqa: B024
         The default length for string columns is stored in _DEFAULT_STR_LENGTH.
         To change this, you can set the _str_lengths class attribute.
 
-    Note on id-columns:
-        Columns that contain ids or reference ids (e.g., 'id', 'from_node', etc.) should be defined in the _id_columns
-        class attribute to
-
-
     Example:
         >>> class MyArray(FancyArray):
         >>>     name: NDArray[np.str_]

--- a/src/power_grid_model_ds/_core/model/arrays/base/array.py
+++ b/src/power_grid_model_ds/_core/model/arrays/base/array.py
@@ -19,7 +19,7 @@ from power_grid_model_ds._core.model.arrays.base._optional import pd
 from power_grid_model_ds._core.model.arrays.base._string import convert_array_to_string
 from power_grid_model_ds._core.model.arrays.base.errors import ArrayDefinitionError
 from power_grid_model_ds._core.model.constants import EMPTY_ID, empty
-from power_grid_model_ds._core.utils.misc import array_equal_with_nan, get_inherited_attrs
+from power_grid_model_ds._core.utils.misc import array_equal_with_nan, get_public_class_attrs, build_mro_attribute
 
 # pylint: disable=missing-function-docstring, too-many-public-methods
 
@@ -44,9 +44,19 @@ class FancyArray(ABC):  # noqa: B024
         >>>     name: NDArray[np.str_]
         >>>     value: NDArray[np.float64]
 
+    Note on default values:
+        Default values for columns can be defined by adding a class attribute _defaults,
+        which is a dictionary mapping column names to their default values.
+        The _defaults attribute is inherited by child classes.
+
     Note on string-columns:
         The default length for string columns is stored in _DEFAULT_STR_LENGTH.
         To change this, you can set the _str_lengths class attribute.
+
+    Note on id-columns:
+        Columns that contain ids or reference ids (e.g., 'id', 'from_node', etc.) should be defined in the _id_columns
+        class attribute to
+
 
     Example:
         >>> class MyArray(FancyArray):
@@ -60,6 +70,7 @@ class FancyArray(ABC):  # noqa: B024
     _data: NDArray = np.ndarray([])
     _defaults: ClassVar[dict[str, Any]] = {}
     _str_lengths: ClassVar[dict[str, int]] = {}
+    _id_columns: ClassVar[set[str]] = set()
 
     def __init__(self, *args, data: NDArray | None = None, **kwargs):
         if data is None:
@@ -74,13 +85,13 @@ class FancyArray(ABC):  # noqa: B024
     @classmethod
     @lru_cache
     def get_defaults(cls) -> dict[str, Any]:
-        return get_inherited_attrs(cls, "_defaults")["_defaults"]
+        return build_mro_attribute(cls, "_defaults", attribute_type=dict)
 
     @classmethod
     @lru_cache
     def get_dtype(cls):
-        annotations = get_inherited_attrs(cls, "_str_lengths")
-        str_lengths = annotations.pop("_str_lengths")
+        annotations = get_public_class_attrs(cls)
+        str_lengths = build_mro_attribute(cls, "_str_lengths", dict)
         dtypes = {}
         for name, dtype in annotations.items():
             if len(dtype.__args__) > 1:

--- a/src/power_grid_model_ds/_core/utils/misc.py
+++ b/src/power_grid_model_ds/_core/utils/misc.py
@@ -5,7 +5,7 @@
 """Misc utils"""
 
 from collections.abc import Sequence
-from typing import get_type_hints, overload
+from typing import get_type_hints
 
 import numpy as np
 
@@ -30,15 +30,7 @@ def get_public_annotations(cls: type):
     return {attr: type_ for attr, type_ in class_attributes.items() if not attr.startswith("_")}
 
 
-@overload
-def build_mro_attribute(cls: type, attribute_name: str, attribute_type: type[dict]) -> dict: ...
-
-
-@overload
-def build_mro_attribute(cls: type, attribute_name: str, attribute_type: type[set]) -> set: ...
-
-
-def build_mro_attribute(cls: type, attribute_name: str, attribute_type) -> dict | set:
+def combine_attribute_from_parent_classes[T: (dict, set)](cls: type, attribute_name: str, attribute_type: type[T]) -> T:
     """Combine all versions of an attribute in the Method Resolution Order (mro) of a class into a single attribute
 
     For dicts this means the dict is updated so that child classes override parent classes.
@@ -48,10 +40,11 @@ def build_mro_attribute(cls: type, attribute_name: str, attribute_type) -> dict 
     """
     attr_value = attribute_type()
     for parent in reversed(list(cls.__mro__)):
+        parent_attr = getattr(parent, attribute_name, attribute_type())
         if attribute_type is dict:
-            attr_value.update(getattr(parent, attribute_name, {}))
+            attr_value.update(parent_attr)
         elif attribute_type is set:
-            attr_value |= getattr(parent, attribute_name, set())
+            attr_value |= parent_attr
         else:
             raise NotImplementedError(
                 f"Type {attribute_type} cannot combine inherited for attribute {attribute_name}. "

--- a/src/power_grid_model_ds/_core/utils/misc.py
+++ b/src/power_grid_model_ds/_core/utils/misc.py
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: MPL-2.0
 
 """Misc utils"""
-
+import typing
 from collections.abc import Sequence
-from typing import get_type_hints
+from typing import get_type_hints, ClassVar
 
 import numpy as np
 
@@ -23,22 +23,32 @@ def is_sequence(seq):
     return isinstance(seq, Sequence)
 
 
-def get_inherited_attrs(cls: type, *private_attributes):
-    """
-    Get the attribute from the object and all its parents
-    """
-
+def get_public_class_attrs(cls: type):
+    """Get the public attributes from the class"""
     # The extras are needed for annotated types like NDArray3
-    retrieved_attributes = get_type_hints(cls, include_extras=True)
-    retrieved_attributes = {attr: type for attr, type in retrieved_attributes.items() if not attr.startswith("_")}
-
-    for private_attr in private_attributes:
-        for parent in reversed(list(cls.__mro__)):
-            attr_dict = retrieved_attributes.get(private_attr, {})
-            attr_dict.update(getattr(parent, private_attr, {}))
-            retrieved_attributes[private_attr] = attr_dict
-
+    class_attributes = get_type_hints(cls, include_extras=True)
+    retrieved_attributes = {attr: type_ for attr, type_ in class_attributes.items() if not attr.startswith("_")}
     return retrieved_attributes
+
+
+def build_mro_attribute(cls: type, attribute_name: str, attribute_type: type[dict] | type[set]) -> dict | set:
+    """Combine all versions of an attribute in the Method Resolution Order (mro) of a class into a single attribute
+
+    For dicts this means the dict is updated so that child classes override parent classes.
+    For sets this means the sets are unioned together.
+
+    Types other than dict and set are not supported
+    """
+    attr_value = attribute_type()
+    for parent in reversed(list(cls.__mro__)):
+        if attribute_type is dict:
+            attr_value.update(getattr(parent, attribute_name, {}))
+        elif attribute_type is set:
+            attr_value |= getattr(parent, attribute_name, set())
+        else:
+            raise NotImplementedError(f"Type {attribute_type} cannot combine inherited for attribute {attribute_name}. "
+                                      f"Only dict and set are currently supported.")
+    return attr_value
 
 
 def array_equal_with_nan(array1: np.ndarray, array2: np.ndarray) -> bool:

--- a/src/power_grid_model_ds/_core/utils/misc.py
+++ b/src/power_grid_model_ds/_core/utils/misc.py
@@ -31,13 +31,11 @@ def get_public_annotations(cls: type):
 
 
 @overload
-def build_mro_attribute(cls: type, attribute_name: str, attribute_type: type[dict]) -> dict:
-    ...
+def build_mro_attribute(cls: type, attribute_name: str, attribute_type: type[dict]) -> dict: ...
 
 
 @overload
-def build_mro_attribute(cls: type, attribute_name: str, attribute_type: type[set]) -> set:
-    ...
+def build_mro_attribute(cls: type, attribute_name: str, attribute_type: type[set]) -> set: ...
 
 
 def build_mro_attribute(cls: type, attribute_name: str, attribute_type) -> dict | set:

--- a/src/power_grid_model_ds/_core/utils/misc.py
+++ b/src/power_grid_model_ds/_core/utils/misc.py
@@ -5,7 +5,7 @@
 """Misc utils"""
 
 from collections.abc import Sequence
-from typing import get_type_hints
+from typing import get_type_hints, overload
 
 import numpy as np
 
@@ -30,7 +30,17 @@ def get_public_annotations(cls: type):
     return {attr: type_ for attr, type_ in class_attributes.items() if not attr.startswith("_")}
 
 
-def build_mro_attribute(cls: type, attribute_name: str, attribute_type: type[dict] | type[set]) -> dict | set:
+@overload
+def build_mro_attribute(cls: type, attribute_name: str, attribute_type: type[dict]) -> dict:
+    ...
+
+
+@overload
+def build_mro_attribute(cls: type, attribute_name: str, attribute_type: type[set]) -> set:
+    ...
+
+
+def build_mro_attribute(cls: type, attribute_name: str, attribute_type) -> dict | set:
     """Combine all versions of an attribute in the Method Resolution Order (mro) of a class into a single attribute
 
     For dicts this means the dict is updated so that child classes override parent classes.

--- a/src/power_grid_model_ds/_core/utils/misc.py
+++ b/src/power_grid_model_ds/_core/utils/misc.py
@@ -5,7 +5,7 @@
 """Misc utils"""
 
 from collections.abc import Sequence
-from typing import get_type_hints, overload
+from typing import get_type_hints
 
 import numpy as np
 
@@ -30,15 +30,7 @@ def get_public_annotations(cls: type):
     return {attr: type_ for attr, type_ in class_attributes.items() if not attr.startswith("_")}
 
 
-@overload
-def build_mro_attribute(cls: type, attribute_name: str, attribute_type: type[dict]) -> dict: ...
-
-
-@overload
-def build_mro_attribute(cls: type, attribute_name: str, attribute_type: type[set]) -> set: ...
-
-
-def build_mro_attribute(cls: type, attribute_name: str, attribute_type) -> dict | set:
+def combine_attribute_from_parent_classes[T: (dict, set)](cls: type, attribute_name: str, attribute_type: type[T]) -> T:
     """Combine all versions of an attribute in the Method Resolution Order (mro) of a class into a single attribute
 
     For dicts this means the dict is updated so that child classes override parent classes.
@@ -46,18 +38,19 @@ def build_mro_attribute(cls: type, attribute_name: str, attribute_type) -> dict 
 
     Types other than dict and set are not supported
     """
-    attr_value = attribute_type()
+    combined_attr = attribute_type()
     for parent in reversed(list(cls.__mro__)):
+        parent_attr = getattr(parent, attribute_name, attribute_type())
         if attribute_type is dict:
-            attr_value.update(getattr(parent, attribute_name, {}))
+            combined_attr.update(parent_attr)
         elif attribute_type is set:
-            attr_value |= getattr(parent, attribute_name, set())
+            combined_attr |= parent_attr
         else:
             raise NotImplementedError(
                 f"Type {attribute_type} cannot combine inherited for attribute {attribute_name}. "
                 f"Only dict and set are currently supported."
             )
-    return attr_value
+    return combined_attr
 
 
 def array_equal_with_nan(array1: np.ndarray, array2: np.ndarray) -> bool:

--- a/src/power_grid_model_ds/_core/utils/misc.py
+++ b/src/power_grid_model_ds/_core/utils/misc.py
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: MPL-2.0
 
 """Misc utils"""
-import typing
+
 from collections.abc import Sequence
-from typing import get_type_hints, ClassVar
+from typing import get_type_hints
 
 import numpy as np
 
@@ -23,12 +23,11 @@ def is_sequence(seq):
     return isinstance(seq, Sequence)
 
 
-def get_public_class_attrs(cls: type):
-    """Get the public attributes from the class"""
-    # The extras are needed for annotated types like NDArray3
+def get_public_annotations(cls: type):
+    """Get the public annotations for a class"""
+    # Note: include_extras=True for annotated types like NDArray3
     class_attributes = get_type_hints(cls, include_extras=True)
-    retrieved_attributes = {attr: type_ for attr, type_ in class_attributes.items() if not attr.startswith("_")}
-    return retrieved_attributes
+    return {attr: type_ for attr, type_ in class_attributes.items() if not attr.startswith("_")}
 
 
 def build_mro_attribute(cls: type, attribute_name: str, attribute_type: type[dict] | type[set]) -> dict | set:
@@ -46,8 +45,10 @@ def build_mro_attribute(cls: type, attribute_name: str, attribute_type: type[dic
         elif attribute_type is set:
             attr_value |= getattr(parent, attribute_name, set())
         else:
-            raise NotImplementedError(f"Type {attribute_type} cannot combine inherited for attribute {attribute_name}. "
-                                      f"Only dict and set are currently supported.")
+            raise NotImplementedError(
+                f"Type {attribute_type} cannot combine inherited for attribute {attribute_name}. "
+                f"Only dict and set are currently supported."
+            )
     return attr_value
 
 

--- a/tests/unit/utils/test_misc.py
+++ b/tests/unit/utils/test_misc.py
@@ -8,7 +8,7 @@ import pytest
 
 from power_grid_model_ds._core.utils.misc import (
     array_equal_with_nan,
-    build_mro_attribute,
+    combine_attribute_from_parent_classes,
     get_public_annotations,
     is_sequence,
 )
@@ -67,16 +67,16 @@ def test_get_public_class_attrs():
 
 
 def test_build_mro_attribute_set():
-    attr = build_mro_attribute(_ChildClass, attribute_name="a", attribute_type=set)
+    attr = combine_attribute_from_parent_classes(_ChildClass, attribute_name="a", attribute_type=set)
     assert attr == {1, 2, 3, 4, 5}
 
 
 def test_build_mro_attribute_dict():
     assert _ChildClass.b == {2: "b", 3: "ccc"}
-    attr = build_mro_attribute(_ChildClass, attribute_name="b", attribute_type=dict)
+    attr = combine_attribute_from_parent_classes(_ChildClass, attribute_name="b", attribute_type=dict)
     assert attr == {1: "a", 2: "b", 3: "ccc"}
 
 
 def test_build_mro_attribute_list():
     with pytest.raises(NotImplementedError):
-        build_mro_attribute(_ChildClass, attribute_name="c", attribute_type=list)
+        combine_attribute_from_parent_classes(_ChildClass, attribute_name="c", attribute_type=list)

--- a/tests/unit/utils/test_misc.py
+++ b/tests/unit/utils/test_misc.py
@@ -49,17 +49,21 @@ def test_array_equal_with_nan():
 class _ParentClass:
     a: ClassVar[set[int]] = {1, 2, 3}
     b: ClassVar[dict[int, str]] = {1: "a", 2: "b", 3: "c"}
-    c: ClassVar[dict[int, str]] = [1, 2, 3]
+    c: ClassVar[list[int]] = [1, 2, 3]
 
 
 class _ChildClass(_ParentClass):
     a: ClassVar[set[int]] = {3, 4, 5}
     b: ClassVar[dict[int, str]] = {2: "b", 3: "ccc"}
-    c: ClassVar[dict[int, str]] = [3, 4, 5]
+    c: ClassVar[list[int]] = [3, 4, 5]
 
 
 def test_get_public_class_attrs():
-    assert get_public_annotations(_ParentClass) == {"a": set, "b": dict, "c": list}
+    assert get_public_annotations(_ParentClass) == {
+        "a": ClassVar[set[int]],
+        "b": ClassVar[dict[int, str]],
+        "c": ClassVar[list[int]],
+    }
 
 
 def test_build_mro_attribute_set():

--- a/tests/unit/utils/test_misc.py
+++ b/tests/unit/utils/test_misc.py
@@ -1,10 +1,17 @@
 # SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
 #
 # SPDX-License-Identifier: MPL-2.0
+from typing import ClassVar
 
 import numpy as np
+import pytest
 
-from power_grid_model_ds._core.utils.misc import array_equal_with_nan, is_sequence
+from power_grid_model_ds._core.utils.misc import (
+    array_equal_with_nan,
+    build_mro_attribute,
+    get_public_annotations,
+    is_sequence,
+)
 
 # pylint: disable=missing-function-docstring
 
@@ -37,3 +44,35 @@ def test_array_equal_with_nan():
     array1 = np.array([(1, 2.0, "a"), (3, np.nan, "b")], dtype=[("col1", "i4"), ("col2", "f4"), ("col3", "U1")])
     array2 = np.array([(1, 2.0, "a"), (3, np.nan, "b")], dtype=[("col1", "i4"), ("col2", "f4"), ("col3", "U1")])
     assert array_equal_with_nan(array1, array2)
+
+
+class _ParentClass:
+    a: ClassVar[set[int]] = {1, 2, 3}
+    b: ClassVar[dict[int, str]] = {1: "a", 2: "b", 3: "c"}
+    c: ClassVar[dict[int, str]] = [1, 2, 3]
+
+
+class _ChildClass(_ParentClass):
+    a: ClassVar[set[int]] = {3, 4, 5}
+    b: ClassVar[dict[int, str]] = {2: "b", 3: "ccc"}
+    c: ClassVar[dict[int, str]] = [3, 4, 5]
+
+
+def test_get_public_class_attrs():
+    assert get_public_annotations(_ParentClass) == {"a": set, "b": dict, "c": list}
+
+
+def test_build_mro_attribute_set():
+    attr = build_mro_attribute(_ChildClass, attribute_name="a", attribute_type=set)
+    assert attr == {1, 2, 3, 4, 5}
+
+
+def test_build_mro_attribute_dict():
+    assert _ChildClass.b == {2: "b", 3: "ccc"}
+    attr = build_mro_attribute(_ChildClass, attribute_name="b", attribute_type=dict)
+    assert attr == {1: "a", 2: "b", 3: "ccc"}
+
+
+def test_build_mro_attribute_list():
+    with pytest.raises(NotImplementedError):
+        build_mro_attribute(_ChildClass, attribute_name="c", attribute_type=list)


### PR DESCRIPTION
PR in preparation of `_id_columns` PR (#243).

Splitted the logic around inherited attributes into two methods.

`build_mro_attribute` supports two types: `dict` and `set`


ToDo:
- [x] fix type issue