### PR TITLE
fix: Improve logic around grid.get_branches() for better performance

### DIFF
--- a/src/power_grid_model_ds/_core/model/grids/_search.py
+++ b/src/power_grid_model_ds/_core/model/grids/_search.py
@@ -22,11 +22,12 @@ if TYPE_CHECKING:
 def get_branches(grid: "Grid") -> BranchArray:
     """see Grid.get_branches()"""
     branch_dtype = BranchArray.get_dtype()
-    branches = BranchArray()
-    for array in grid.branch_arrays:
-        new_branch = BranchArray(data=array.data[list(branch_dtype.names)])
-        branches = fp.concatenate(branches, new_branch)
-    return branches
+    branch_columns = list(branch_dtype.names)
+    branch_arrays = get_branch_arrays(grid)
+    consistent_branch_arrays = [array[branch_columns] for array in branch_arrays if array.size]
+    if len(consistent_branch_arrays) == 0:
+        return BranchArray()
+    return fp.concatenate(BranchArray(), *consistent_branch_arrays)
 
 
 def get_branch_arrays(grid: "Grid") -> list[BranchArray]:


### PR DESCRIPTION
Fixes #238

### Changes proposed in this PR include
Concatenate once is faster. So we now prepare the arrays in the list and concatenate once instead of concatenate each individually. This will help speed-up the get_branches function.
