### PR TITLE
Remove all code related to Grid.add_node and Grid.add_branch (Breaking)

### DIFF
--- a/docs/examples/model/grid_examples.ipynb
+++ b/docs/examples/model/grid_examples.ipynb
@@ -272,7 +272,7 @@
     "\n",
     "### Adding a Line\n",
     "\n",
-    "To add a line to the grid, use the `add_branch` method with a `LineArray` object. This method adds a new line between specified nodes.\n"
+    "To add a line to the grid, use the `append` method with a `LineArray` object. This method adds a new line between specified nodes.\n"
    ]
   },
   {
@@ -286,7 +286,7 @@
     "new_line_array = LineArray.zeros(1)\n",
     "new_line_array.from_node = 102\n",
     "new_line_array.to_node = 105\n",
-    "grid.add_branch(branch=new_line_array)"
+    "grid.append(new_line_array)"
    ]
   },
   {
@@ -318,7 +318,7 @@
     "\n",
     "### Adding a Link\n",
     "\n",
-    "To add a link to the grid, use the `add_branch` method with a `LinkArray` object. This method adds a new link between specified nodes.\n"
+    "To add a link to the grid, use the `append` method with a `LinkArray` object. This method adds a new link between specified nodes.\n"
    ]
   },
   {
@@ -332,7 +332,7 @@
     "new_link_array = LinkArray.zeros(1)\n",
     "new_link_array.from_node = 102\n",
     "new_link_array.to_node = 105\n",
-    "grid.add_branch(branch=new_link_array)"
+    "grid.append(new_link_array)"
    ]
   },
   {
@@ -343,7 +343,7 @@
     "\n",
     "### Adding a Transformer\n",
     "\n",
-    "To add a transformer to the grid, use the `add_branch` method with a `TransformerArray` object. This method adds a new transformer between specified nodes.\n"
+    "To add a transformer to the grid, use the `append` method with a `TransformerArray` object. This method adds a new transformer between specified nodes.\n"
    ]
   },
   {
@@ -357,7 +357,7 @@
     "new_transformer_array = TransformerArray.zeros(1)\n",
     "new_transformer_array.from_node = 102\n",
     "new_transformer_array.to_node = 105\n",
-    "grid.add_branch(branch=new_transformer_array)"
+    "grid.append(new_transformer_array)"
    ]
   },
   {
@@ -461,7 +461,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv (3.12.6)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -474,9 +474,10 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.14.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/docs/examples/model/grid_examples.ipynb
+++ b/docs/examples/model/grid_examples.ipynb
@@ -228,7 +228,7 @@
     "\n",
     "### Adding a Node\n",
     "\n",
-    "To add a node to the grid, use the `add_node` method. This method adds a new node to the grid's node array.\n"
+    "To add a node to the grid, use the `append` method. This method adds a new node to the grid's node array.\n"
    ]
   },
   {
@@ -240,7 +240,7 @@
     "from power_grid_model_ds.arrays import NodeArray\n",
     "\n",
     "new_node = NodeArray.zeros(1)\n",
-    "grid.add_node(node=new_node)"
+    "grid.append(new_node)"
    ]
   },
   {

--- a/docs/model_interface.ipynb
+++ b/docs/model_interface.ipynb
@@ -73,7 +73,7 @@
     "new_line_array = LineArray.zeros(1)\n",
     "new_line_array.from_node = 2\n",
     "new_line_array.to_node = 5\n",
-    "grid.add_branch(branch=new_line_array)"
+    "grid.append(new_line_array)"
    ]
   },
   {

--- a/docs/quick_start.ipynb
+++ b/docs/quick_start.ipynb
@@ -156,7 +156,7 @@
     "    c1=[0.0],\n",
     ")\n",
     "\n",
-    "grid.add_branch(branch=new_line)\n",
+    "grid.append(new_line)\n",
     "\n",
     "old_line = grid.line.get(19)\n",
     "grid.make_inactive(branch=old_line)"

--- a/src/power_grid_model_ds/_core/model/grids/_modify.py
+++ b/src/power_grid_model_ds/_core/model/grids/_modify.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 import logging
-import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -28,33 +27,6 @@ def add_array_to_grid(grid: "Grid", array: FancyArray, check_max_id: bool = True
     grid._append(array, check_max_id=check_max_id)  # noqa # pylint: disable=protected-access
     # pylint: disable=protected-access
     grid.graphs._append(array)  # noqa: SLF001
-
-
-def add_node(grid: "Grid", node: NodeArray) -> None:
-    """See Grid.add_node()"""
-    warnings.warn(
-        "Grid.add_node is deprecated and will be removed in a future release. Use Grid.append instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    grid._append(array=node)  # noqa # pylint: disable=protected-access
-    grid.graphs.add_node_array(node_array=node)
-    _logger.debug("added node %s", node.id.tolist())
-
-
-def add_branch(grid: "Grid", branch: BranchArray) -> None:
-    """See Grid.add_branch()"""
-    warnings.warn(
-        "Grid.add_branch is deprecated and will be removed in a future release. Use Grid.append instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    grid._append(array=branch)  # noqa # pylint: disable=protected-access
-    grid.graphs.add_branch_array(branch_array=branch)
-
-    _logger.debug(
-        "added branch %s from %s to %s", branch.id.tolist(), branch.from_node.tolist(), branch.to_node.tolist()
-    )
 
 
 def make_active(grid: "Grid", branch: BranchArray) -> None:

--- a/src/power_grid_model_ds/_core/model/grids/base.py
+++ b/src/power_grid_model_ds/_core/model/grids/base.py
@@ -24,8 +24,6 @@ from power_grid_model_ds._core.model.grids._helpers import (
 )
 from power_grid_model_ds._core.model.grids._modify import (
     add_array_to_grid,
-    add_branch,
-    add_node,
     delete_branch,
     delete_branch3,
     delete_node,
@@ -214,14 +212,6 @@ class Grid(FancyArrayContainer):
         """
         return add_array_to_grid(self, array=array, check_max_id=check_max_id)
 
-    def add_branch(self, branch: BranchArray) -> None:
-        """Add a branch to the grid
-
-        Args:
-            branch (BranchArray): The branch to add
-        """
-        return add_branch(self, branch)
-
     def delete_branch(self, branch: BranchArray) -> None:
         """Remove a branch array from the grid
 
@@ -244,14 +234,6 @@ class Grid(FancyArrayContainer):
             branch (Branch3Array): The branch3 array to remove
         """
         return delete_branch3(self, branch=branch)
-
-    def add_node(self, node: NodeArray) -> None:
-        """Add a new node to the grid
-
-        Args:
-            node (NodeArray): The node to add
-        """
-        return add_node(self, node=node)
 
     def delete_node(self, node: NodeArray) -> None:
         """Remove a node array from the grid

--- a/tests/performance/graph_performance_tests.py
+++ b/tests/performance/graph_performance_tests.py
@@ -38,9 +38,9 @@ def perftest_rebuild_graphs():
     do_performance_test(code_to_test, GRAPH_SIZES, 100, setup_codes=GRAPH_SETUP_CODES)
 
 
-def perftest_add_node():
+def perftest_append_node():
     code_to_test = (
-        "from power_grid_model_ds.arrays import NodeArray;new_node = NodeArray.zeros(1);grid.add_node(node=new_node)"
+        "from power_grid_model_ds.arrays import NodeArray;new_node = NodeArray.zeros(1);grid.append(new_node)"
     )
     do_performance_test(code_to_test, GRAPH_SIZES, 100, setup_codes=GRAPH_SETUP_CODES)
 
@@ -50,5 +50,5 @@ if __name__ == "__main__":
     perftest_set_feeder_ids()
     perftest_get_components()
     perftest_delete_node()
-    perftest_add_node()
+    perftest_append_node()
     perftest_rebuild_graphs()

--- a/tests/unit/model/grids/test_modify.py
+++ b/tests/unit/model/grids/test_modify.py
@@ -28,11 +28,11 @@ from tests.fixtures.arrays import DefaultedCustomLineArray, DefaultedCustomNodeA
 from tests.fixtures.grid_classes import ExtendedGrid
 
 
-def test_grid_add_node(basic_grid: Grid):
+def test_grid_append_node(basic_grid: Grid):
     grid = basic_grid
 
     new_node = NodeArray.zeros(1)
-    grid.add_node(node=new_node)
+    grid.append(new_node)
 
     assert len(grid.node) == 7
     assert EMPTY_ID not in grid.node.id


### PR DESCRIPTION
Remove two Grid methods that had been marked for deprecation:

- Grid.add_node()
- Grid.add_branch()

Both have been replace by Grid.append()