### PR TITLE
fix: support numpy v2.5

### DIFF
--- a/src/power_grid_model_ds/_core/model/arrays/base/array.py
+++ b/src/power_grid_model_ds/_core/model/arrays/base/array.py
@@ -119,10 +119,10 @@ class FancyArray(ABC):  # noqa: B024
             elif is_before_numpy_25 and len(type_args) == 2 and get_origin(type_args[1]) is Literal:  # noqa: PLR2004
                 dtypes[name] = (get_args(get_args(type_args[0])[1])[0], get_args(type_args[1])[0])
             # Expected type_args post-2.5 for NDArray: (numpy.int32,)
-            elif len(type_args) == 1:
+            elif len(type_args) == 1: # pragma: no cover
                 dtypes[name] = type_args[0]
             # Expected type_args post-2.5 for NDArray3: (NDArray[numpy.float64], typing.Literal[3])
-            elif len(type_args) == 2:  # noqa: PLR2004
+            elif len(type_args) == 2:  # noqa: PLR2004 # pragma: no cover
                 dtypes[name] = (get_args(type_args[0])[0], get_args(type_args[1])[0])
             else:
                 raise ValueError(f"dtype {type_def} not understood or supported")

--- a/src/power_grid_model_ds/_core/model/arrays/base/array.py
+++ b/src/power_grid_model_ds/_core/model/arrays/base/array.py
@@ -100,7 +100,7 @@ class FancyArray(ABC):  # noqa: B024
 
     @classmethod
     @lru_cache
-    def get_dtype(cls): # noqa: python:S3776
+    def get_dtype(cls):  # noqa: python:S3776
         annotations = get_public_annotations(cls)
         str_lengths = combine_attribute_from_parent_classes(cls, "_str_lengths", dict)
         dtypes = {}
@@ -119,7 +119,7 @@ class FancyArray(ABC):  # noqa: B024
             elif is_before_numpy_25 and len(type_args) == 2 and get_origin(type_args[1]) is Literal:  # noqa: PLR2004
                 dtypes[name] = (get_args(get_args(type_args[0])[1])[0], get_args(type_args[1])[0])
             # Expected type_args post-2.5 for NDArray: (numpy.int32,)
-            elif len(type_args) == 1: # pragma: no cover
+            elif len(type_args) == 1:  # pragma: no cover
                 dtypes[name] = type_args[0]
             # Expected type_args post-2.5 for NDArray3: (NDArray[numpy.float64], typing.Literal[3])
             elif len(type_args) == 2:  # noqa: PLR2004 # pragma: no cover

--- a/src/power_grid_model_ds/_core/model/arrays/base/array.py
+++ b/src/power_grid_model_ds/_core/model/arrays/base/array.py
@@ -133,14 +133,14 @@ class FancyArray(ABC):  # noqa: B024
             raise ArrayDefinitionError(f"Columns cannot be reserved names: {reserved}")
 
         dtype_list = []
-        for name, type_def in dtypes.items():
-            if type_def is np.str_:
+        for name, dtype in dtypes.items():
+            if dtype is np.str_:
                 string_length = str_lengths.get(name, _DEFAULT_STR_LENGTH)
                 dtype_list.append((name, np.dtype(f"U{string_length}")))
-            elif type_def is tuple:
-                dtype_list.append((name, *type_def))
+            elif dtype is tuple:
+                dtype_list.append((name, *dtype))
             else:
-                dtype_list.append((name, type_def))
+                dtype_list.append((name, dtype))
         return np.dtype(dtype_list)
 
     def __repr__(self) -> str:

--- a/src/power_grid_model_ds/_core/model/arrays/base/array.py
+++ b/src/power_grid_model_ds/_core/model/arrays/base/array.py
@@ -100,7 +100,7 @@ class FancyArray(ABC):  # noqa: B024
 
     @classmethod
     @lru_cache
-    def get_dtype(cls):
+    def get_dtype(cls): # noqa: python:S3776
         annotations = get_public_annotations(cls)
         str_lengths = combine_attribute_from_parent_classes(cls, "_str_lengths", dict)
         dtypes = {}
@@ -108,24 +108,24 @@ class FancyArray(ABC):  # noqa: B024
         # Numpy 2.5 changed the typing interface, so we need to treat these differently
         is_before_numpy_25 = version.parse(np.__version__) < version.parse("2.5.0")
 
-        for name, dtype in annotations.items():
-            dtype_args = get_args(dtype)
+        for name, type_def in annotations.items():
+            type_args = get_args(type_def)
 
-            # Expected dtype_args pre-2.5 for NDArray[]: (tuple[typing.Any, ...], numpy.dtype[numpy.int32])
-            if is_before_numpy_25 and len(dtype_args) == 2 and get_origin(dtype_args[1]) is np.dtype:  # noqa: PLR2004
-                dtypes[name] = get_args(dtype_args[1])[0]
-            # Expected dtype_args pre-2.5 for NDArray3[]:
+            # Expected type_args pre-2.5 for NDArray[]: (tuple[typing.Any, ...], numpy.dtype[numpy.int32])
+            if is_before_numpy_25 and len(type_args) == 2 and get_origin(type_args[1]) is np.dtype:  # noqa: PLR2004
+                dtypes[name] = get_args(type_args[1])[0]
+            # Expected type_args pre-2.5 for NDArray3[]:
             # (numpy.ndarray[tuple[typing.Any, ...], numpy.dtype[numpy.float64]], typing.Literal[3])
-            elif is_before_numpy_25 and len(dtype_args) == 2 and get_origin(dtype_args[1]) is Literal:  # noqa: PLR2004
-                dtypes[name] = (get_args(get_args(dtype_args[0])[1])[0], get_args(dtype_args[1])[0])
-            # Expected dtype_args post-2.5 for NDArray: (numpy.int32,)
-            elif len(dtype_args) == 1:
-                dtypes[name] = dtype_args[0]
-            # Expected dtype_args post-2.5 for NDArray3: (NDArray[numpy.float64], typing.Literal[3])
-            elif len(dtype_args) == 2:  # noqa: PLR2004
-                dtypes[name] = (get_args(dtype_args[0])[0], get_args(dtype_args[1])[0])
+            elif is_before_numpy_25 and len(type_args) == 2 and get_origin(type_args[1]) is Literal:  # noqa: PLR2004
+                dtypes[name] = (get_args(get_args(type_args[0])[1])[0], get_args(type_args[1])[0])
+            # Expected type_args post-2.5 for NDArray: (numpy.int32,)
+            elif len(type_args) == 1:
+                dtypes[name] = type_args[0]
+            # Expected type_args post-2.5 for NDArray3: (NDArray[numpy.float64], typing.Literal[3])
+            elif len(type_args) == 2:  # noqa: PLR2004
+                dtypes[name] = (get_args(type_args[0])[0], get_args(type_args[1])[0])
             else:
-                raise ValueError(f"dtype {dtype} not understood or supported")
+                raise ValueError(f"dtype {type_def} not understood or supported")
 
         if not dtypes:
             raise ArrayDefinitionError("Array has no defined Columns")
@@ -133,14 +133,14 @@ class FancyArray(ABC):  # noqa: B024
             raise ArrayDefinitionError(f"Columns cannot be reserved names: {reserved}")
 
         dtype_list = []
-        for name, dtype in dtypes.items():
-            if dtype is np.str_:
+        for name, type_def in dtypes.items():
+            if type_def is np.str_:
                 string_length = str_lengths.get(name, _DEFAULT_STR_LENGTH)
                 dtype_list.append((name, np.dtype(f"U{string_length}")))
-            elif dtype is tuple:
-                dtype_list.append((name, *dtype))
+            elif type_def is tuple:
+                dtype_list.append((name, *type_def))
             else:
-                dtype_list.append((name, dtype))
+                dtype_list.append((name, type_def))
         return np.dtype(dtype_list)
 
     def __repr__(self) -> str:

--- a/src/power_grid_model_ds/_core/model/arrays/base/array.py
+++ b/src/power_grid_model_ds/_core/model/arrays/base/array.py
@@ -7,10 +7,11 @@ from collections import namedtuple
 from collections.abc import Iterable
 from copy import copy
 from functools import lru_cache
-from typing import Any, ClassVar, Literal, TypeVar, overload
+from typing import Any, ClassVar, Literal, TypeVar, get_args, get_origin, overload
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
+from packaging import version
 
 from power_grid_model_ds._core.model.arrays.base._build import build_array
 from power_grid_model_ds._core.model.arrays.base._filters import apply_exclude, apply_filter, apply_get, get_filter_mask
@@ -103,17 +104,26 @@ class FancyArray(ABC):  # noqa: B024
         annotations = get_public_annotations(cls)
         str_lengths = combine_attribute_from_parent_classes(cls, "_str_lengths", dict)
         dtypes = {}
+
+        # Numpy 2.5 changed the typing interface, so we need to treat these differently
+        is_before_numpy_25 = version.parse(np.__version__) < version.parse("2.5.0")
+
         for name, dtype in annotations.items():
-            if len(dtype.__args__) > 1:
-                # regular numpy dtype (i.e. without shape)
-                dtypes[name] = dtype.__args__[1].__args__[0]
-            elif hasattr(dtype, "__metadata__"):
-                # metadata annotation contains shape
-                # define dtype using a (type, shape) tuple
-                # see: #1 in https://numpy.org/doc/stable/user/basics.rec.html#structured-datatype-creation
-                dtype_type = dtype.__args__[0].__args__[1].__args__[0]
-                dtype_shape = dtype.__metadata__[0].__args__
-                dtypes[name] = (dtype_type, dtype_shape)
+            dtype_args = get_args(dtype)
+
+            # Expected dtype_args pre-2.5 for NDArray[]: (tuple[typing.Any, ...], numpy.dtype[numpy.int32])
+            if is_before_numpy_25 and len(dtype_args) == 2 and get_origin(dtype_args[1]) is np.dtype:  # noqa: PLR2004
+                dtypes[name] = get_args(dtype_args[1])[0]
+            # Expected dtype_args pre-2.5 for NDArray3[]:
+            # (numpy.ndarray[tuple[typing.Any, ...], numpy.dtype[numpy.float64]], typing.Literal[3])
+            elif is_before_numpy_25 and len(dtype_args) == 2 and get_origin(dtype_args[1]) is Literal:  # noqa: PLR2004
+                dtypes[name] = (get_args(get_args(dtype_args[0])[1])[0], get_args(dtype_args[1])[0])
+            # Expected dtype_args post-2.5 for NDArray: (numpy.int32,)
+            elif len(dtype_args) == 1:
+                dtypes[name] = dtype_args[0]
+            # Expected dtype_args post-2.5 for NDArray3: (NDArray[numpy.float64], typing.Literal[3])
+            elif len(dtype_args) == 2:  # noqa: PLR2004
+                dtypes[name] = (get_args(dtype_args[0])[0], get_args(dtype_args[1])[0])
             else:
                 raise ValueError(f"dtype {dtype} not understood or supported")
 


### PR DESCRIPTION
Fixes #282 

The `.__args__` on `NDArray` has changed in numpy v2.5. Also in general is it not recommended to use `__args__` directly, instead we should use `get_args` from typing. 

The current PR checks if the version of numpy is below or above 2.5 and uses the logic that is needed based on this. I think it is also possible to recognize the case without the version check, but think this would make things harder to understand. Let me know whether there are good reasons not to have a version check. 

The tests in this PR are successful with numpy 2.4 and it is also successful in the nightly again: https://github.com/PowerGridModel/power-grid-model-ds/actions/runs/28232535881

Unfortunately all the code is quite "magic" in the sense that there a lot of random `get_args` calls and specific indices that we pick to make it work. I don't see a better way of doing it, given the current setup. 

## Changes
- For the pre-2.5 cases I rewrote the logic to use get_args instead of `__args__`
- Added new logic to support the new 2.5 output


## Remarks
- Sonarcloud isn't happy because two of the paths aren't hit in the coverage. This is the case because we currently still have 2.4 in our lock file, so the if statements for numpy 2.5 are not hit as expected. If/When we update, this will be different. 
_I have added a comment to not track coverage for these if-statements._ 
- Sonarcloud isn't happy because of the complexity of the function. I agree that the function is too complex currently, but have ignored it for now. This is a minimal fix to get things working again.
- We might support a bit less now if people had fancy types, similar to `NDArray3`. Since we now explicitly check whether the second passed argument is a `Literal`. We could loosen this and/or add extra options there, for instance an `int`. But personally would be fine with merging as-is and see if we get any feedback on 