### PR TITLE
store max_id to prevent having to recalculate

### DIFF
--- a/src/power_grid_model_ds/_core/model/containers/_id_tracker.py
+++ b/src/power_grid_model_ds/_core/model/containers/_id_tracker.py
@@ -11,18 +11,22 @@ class IdTracker:
     __hash__ = None
 
     def __init__(self, ids: set[int] | None = None) -> None:
+        """Initialize the tracker with an optional set of ids."""
         self._ids = set(ids) if ids is not None else set()
         self._max_id = max(self._ids) if self._ids else 0
 
     @property
     def ids(self) -> set[int]:
+        """Return the tracked ids."""
         return self._ids
 
     @property
     def max_id(self) -> int:
+        """Return the cached maximum id."""
         return self._max_id
 
     def add(self, new_ids: set[int], max_new_id: int | None = None) -> None:
+        """Add ids and update the cached maximum id."""
         self._ids |= new_ids
         if max_new_id is not None:
             self._max_id = max(self._max_id, max_new_id)

--- a/src/power_grid_model_ds/_core/model/containers/_id_tracker.py
+++ b/src/power_grid_model_ds/_core/model/containers/_id_tracker.py
@@ -8,6 +8,8 @@
 class IdTracker:
     """Wrapper around a set of ids that keeps track of the maximum id."""
 
+    __hash__ = None
+
     def __init__(self, ids: set[int] | None = None) -> None:
         self._ids = set(ids) if ids is not None else set()
         self._max_id = max(self._ids) if self._ids else 0
@@ -25,7 +27,7 @@ class IdTracker:
         if max_new_id is not None:
             self._max_id = max(self._max_id, max_new_id)
         elif new_ids:
-            self._max_id = max(self._max_id, max(new_ids))
+            self._max_id = max(self._max_id, *new_ids)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, self.__class__):

--- a/src/power_grid_model_ds/_core/model/containers/_id_tracker.py
+++ b/src/power_grid_model_ds/_core/model/containers/_id_tracker.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+"""Tracks a set of ids and its maximum value."""
+
+
+class IdTracker:
+    """Wrapper around a set of ids that keeps track of the maximum id."""
+
+    def __init__(self, ids: set[int] | None = None) -> None:
+        self._ids = set(ids) if ids is not None else set()
+        self._max_id = max(self._ids) if self._ids else 0
+
+    @property
+    def ids(self) -> set[int]:
+        return self._ids
+
+    @property
+    def max_id(self) -> int:
+        return self._max_id
+
+    def add(self, new_ids: set[int], max_new_id: int | None = None) -> None:
+        self._ids |= new_ids
+        if max_new_id is not None:
+            self._max_id = max(self._max_id, max_new_id)
+        elif new_ids:
+            self._max_id = max(self._max_id, max(new_ids))
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, self.__class__):
+            return False
+        return self._ids == other._ids and self._max_id == other._max_id

--- a/src/power_grid_model_ds/_core/model/containers/base.py
+++ b/src/power_grid_model_ds/_core/model/containers/base.py
@@ -46,7 +46,7 @@ class FancyArrayContainer:
 
     @property
     def max_id(self) -> int:
-        """Returns the max id across all arrays within the container."""
+        """Returns the cached max id across all arrays within the container."""
         return self._max_id
 
     def rebuild_ids(self) -> None:

--- a/src/power_grid_model_ds/_core/model/containers/base.py
+++ b/src/power_grid_model_ds/_core/model/containers/base.py
@@ -16,6 +16,7 @@ from power_grid_model_ds._core import fancypy as fp
 from power_grid_model_ds._core.model.arrays.base.array import FancyArray
 from power_grid_model_ds._core.model.arrays.base.errors import RecordDoesNotExist
 from power_grid_model_ds._core.model.constants import EMPTY_ID
+from power_grid_model_ds._core.model.containers._id_tracker import IdTracker
 from power_grid_model_ds._core.model.containers.helpers import container_equal
 
 _logger = logging.getLogger(__name__)
@@ -30,8 +31,7 @@ class FancyArrayContainer:
     Contains general functionality that is nonspecific to the type of array being stored.
     """
 
-    _ids: set[int]
-    _max_id: int
+    _id_tracker: IdTracker
     __hash__ = None
 
     def __eq__(self, other) -> bool:
@@ -42,15 +42,15 @@ class FancyArrayContainer:
     @property
     def ids(self):
         """Returns the ids across all arrays"""
-        return self._ids
+        return self._id_tracker.ids
 
     @property
     def max_id(self) -> int:
         """Returns the cached max id across all arrays within the container."""
-        return self._max_id
+        return self._id_tracker.max_id
 
     def rebuild_ids(self) -> None:
-        """Rebuild self._ids based on the arrays in the container.
+        """Rebuild the id tracker based on the arrays in the container.
 
         Raises:
             ValueError: if duplicate ids are found between or within arrays.
@@ -66,8 +66,7 @@ class FancyArrayContainer:
                 raise ValueError(f"Duplicate ids found between arrays ({array.__class__.__name__})")
             new_ids |= array_ids
 
-        self._ids = new_ids
-        self._max_id = max(new_ids) if new_ids else 0
+        self._id_tracker = IdTracker(new_ids)
 
     def check_ids(self, check_between_arrays: bool = True, check_within_arrays: bool = True) -> None:
         """Checks for duplicate id values across all arrays in the container.
@@ -126,7 +125,7 @@ class FancyArrayContainer:
         self._append(array=array, check_max_id=check_max_id)
 
     def attach_ids(self, array: FancyArray) -> FancyArray:
-        """Generate and attach ids to the given FancyArray. Also updates _ids.
+        """Generate and attach ids to the given FancyArray. Also updates the id tracker.
 
         Args:
             array(FancyArray): the array of which the id column is set.
@@ -143,8 +142,7 @@ class FancyArrayContainer:
         start = self.max_id + 1
         end = start + len(array)
         array.id = np.arange(start, end)
-        self._ids |= set(array.id.tolist())
-        self._max_id = end - 1
+        self._id_tracker.add(set(array.id.tolist()), max_new_id=end - 1)
         return array
 
     def search_for_id(self, record_id: int) -> list[FancyArray]:
@@ -225,7 +223,7 @@ class FancyArrayContainer:
         empty_fields = {}
 
         empty_fields.update(cls._get_empty_arrays())
-        empty_fields.update({"_ids": set(), "_max_id": 0})
+        empty_fields.update({"_id_tracker": IdTracker()})
         return empty_fields
 
     @classmethod
@@ -245,11 +243,9 @@ class FancyArrayContainer:
 
         new_ids = set(array.id.tolist())
 
-        if check_max_id and (overlap := self._ids & new_ids):
+        if check_max_id and (overlap := self._id_tracker.ids & new_ids):
             raise ValueError(f"Cannot append, array contains ids that already exist: {overlap}")
-        self._ids |= new_ids
-        if new_ids:
-            self._max_id = max(self._max_id, max(new_ids))
+        self._id_tracker.add(new_ids)
 
     @staticmethod
     def _get_duplicates_between_arrays(id_arrays: list[FancyArray], check: bool) -> np.ndarray:

--- a/src/power_grid_model_ds/_core/model/containers/base.py
+++ b/src/power_grid_model_ds/_core/model/containers/base.py
@@ -31,6 +31,7 @@ class FancyArrayContainer:
     """
 
     _ids: set[int]
+    _max_id: int
     __hash__ = None
 
     def __eq__(self, other) -> bool:
@@ -46,7 +47,7 @@ class FancyArrayContainer:
     @property
     def max_id(self) -> int:
         """Returns the max id across all arrays within the container."""
-        return max(self._ids) if self._ids else 0
+        return self._max_id
 
     def rebuild_ids(self) -> None:
         """Rebuild self._ids based on the arrays in the container.
@@ -66,6 +67,7 @@ class FancyArrayContainer:
             new_ids |= array_ids
 
         self._ids = new_ids
+        self._max_id = max(new_ids) if new_ids else 0
 
     def check_ids(self, check_between_arrays: bool = True, check_within_arrays: bool = True) -> None:
         """Checks for duplicate id values across all arrays in the container.
@@ -142,6 +144,7 @@ class FancyArrayContainer:
         end = start + len(array)
         array.id = np.arange(start, end)
         self._ids |= set(array.id.tolist())
+        self._max_id = end - 1
         return array
 
     def search_for_id(self, record_id: int) -> list[FancyArray]:
@@ -222,7 +225,7 @@ class FancyArrayContainer:
         empty_fields = {}
 
         empty_fields.update(cls._get_empty_arrays())
-        empty_fields.update({"_ids": set()})
+        empty_fields.update({"_ids": set(), "_max_id": 0})
         return empty_fields
 
     @classmethod
@@ -245,6 +248,8 @@ class FancyArrayContainer:
         if check_max_id and (overlap := self._ids & new_ids):
             raise ValueError(f"Cannot append, array contains ids that already exist: {overlap}")
         self._ids |= new_ids
+        if new_ids:
+            self._max_id = max(self._max_id, max(new_ids))
 
     @staticmethod
     def _get_duplicates_between_arrays(id_arrays: list[FancyArray], check: bool) -> np.ndarray:

--- a/src/power_grid_model_ds/_core/model/grids/_search.py
+++ b/src/power_grid_model_ds/_core/model/grids/_search.py
@@ -113,7 +113,7 @@ def _print_differences(differences: dict[str, dict[str, object]]) -> None:
         print(f"\n{title}")
         print("-" * len(title))
 
-        if attr in ["_ids", "graphs"]:
+        if attr in ["_ids", "_max_id", "graphs"]:
             continue  # more info is not relevant for these attributes
 
         print(diff["grid1"])

--- a/src/power_grid_model_ds/_core/model/grids/_search.py
+++ b/src/power_grid_model_ds/_core/model/grids/_search.py
@@ -113,7 +113,7 @@ def _print_differences(differences: dict[str, dict[str, object]]) -> None:
         print(f"\n{title}")
         print("-" * len(title))
 
-        if attr in ["_ids", "_max_id", "graphs"]:
+        if attr in ["_id_tracker", "graphs"]:
             continue  # more info is not relevant for these attributes
 
         print(diff["grid1"])

--- a/src/power_grid_model_ds/_core/model/grids/serialization/json.py
+++ b/src/power_grid_model_ds/_core/model/grids/serialization/json.py
@@ -53,7 +53,7 @@ def serialize_to_dict[G: Grid](grid: G, strict: bool = True, **kwargs) -> dict:
     serialized_data = {}
 
     for field in dataclasses.fields(grid):
-        if field.name in ["graphs", "_ids"]:
+        if field.name in ["graphs", "_ids", "_max_id"]:
             continue
 
         field_value = getattr(grid, field.name)

--- a/src/power_grid_model_ds/_core/model/grids/serialization/json.py
+++ b/src/power_grid_model_ds/_core/model/grids/serialization/json.py
@@ -53,7 +53,7 @@ def serialize_to_dict[G: Grid](grid: G, strict: bool = True, **kwargs) -> dict:
     serialized_data = {}
 
     for field in dataclasses.fields(grid):
-        if field.name in ["graphs", "_ids", "_max_id"]:
+        if field.name in ["graphs", "_id_tracker"]:
             continue
 
         field_value = getattr(grid, field.name)

--- a/tests/unit/model/containers/test_base.py
+++ b/tests/unit/model/containers/test_base.py
@@ -192,8 +192,10 @@ def test_rebuild_ids():
     expected_ids = {1, 2, 3, 10, 11, 20, 21, 22}
     assert grid.ids == expected_ids
     grid._ids = set()
+    grid._max_id = 0
     grid.rebuild_ids()
     assert grid.ids == expected_ids
+    assert grid.max_id == max(expected_ids)
 
 
 def test_rebuild_ids_with_duplicates():
@@ -206,3 +208,111 @@ def test_rebuild_ids_with_duplicates():
 def test_ids():
     grid = Grid.from_txt("1 2 20", "2 3 21", "10 11 22")
     assert grid.ids == {1, 2, 3, 10, 11, 20, 21, 22}
+
+
+def test_max_id_empty_container():
+    container = FancyArrayContainer.empty()
+    assert container.max_id == 0
+    assert container._max_id == 0
+
+
+def test_max_id_after_append_with_explicit_ids():
+    grid = Grid.empty()
+    nodes = NodeArray.zeros(3)
+    nodes.id = [1, 2, 5]
+    grid.append(nodes)
+    assert grid.max_id == 5
+    assert grid._max_id == 5
+
+
+def test_max_id_after_append_with_lower_ids():
+    grid = Grid.empty()
+    nodes = NodeArray.zeros(2)
+    nodes.id = [10, 20]
+    grid.append(nodes)
+    assert grid.max_id == 20
+
+    lines = LineArray.zeros(2)
+    lines.id = [3, 4]
+    lines.from_node = [10, 10]
+    lines.to_node = [20, 20]
+    grid.append(lines)
+    assert grid.max_id == 20
+    assert grid._max_id == 20
+
+
+def test_max_id_after_append_with_higher_ids():
+    grid = Grid.empty()
+    nodes = NodeArray.zeros(2)
+    nodes.id = [1, 2]
+    grid.append(nodes)
+    assert grid.max_id == 2
+
+    more_nodes = NodeArray.zeros(2)
+    more_nodes.id = [8, 9]
+    grid.append(more_nodes)
+    assert grid.max_id == 9
+    assert grid._max_id == 9
+
+
+def test_max_id_after_attach_ids():
+    grid = Grid.empty()
+    nodes = NodeArray.zeros(3)
+    grid.append(nodes)  # empty ids -> attach_ids
+    assert set(grid.node.id.tolist()) == {1, 2, 3}
+    assert grid.max_id == 3
+    assert grid._max_id == 3
+
+    more_nodes = NodeArray.zeros(2)
+    grid.append(more_nodes)
+    assert set(more_nodes.id.tolist()) == {4, 5}
+    assert grid.max_id == 5
+    assert grid._max_id == 5
+
+
+def test_max_id_attach_ids_directly():
+    grid = Grid.empty()
+    nodes = NodeArray.zeros(2)
+    grid.attach_ids(nodes)
+    assert nodes.id.tolist() == [1, 2]
+    assert grid.max_id == 2
+    assert grid.ids == {1, 2}
+
+
+def test_max_id_after_rebuild_ids_decreases():
+    grid = Grid.from_txt("1 2 20", "2 3 21", "10 11 22")
+    assert grid.max_id == 22
+
+    grid.node = grid.node.exclude(id=11)
+    grid.line = grid.line.exclude(id=22)
+    grid.rebuild_ids()
+
+    assert grid.ids == {1, 2, 3, 10, 20, 21}
+    assert grid.max_id == 21
+    assert grid._max_id == 21
+
+
+def test_max_id_after_rebuild_ids_empty():
+    grid = Grid.empty()
+    grid._ids = {99}
+    grid._max_id = 99
+    grid.rebuild_ids()
+    assert grid.ids == set()
+    assert grid.max_id == 0
+
+
+def test_max_id_after_delete_via_grid_api():
+    grid = Grid.from_txt("1 2 20", "2 3 21", "10 11 22")
+    assert grid.max_id == 22
+
+    branch = grid.line.get(id=22)
+    grid.delete_branch(branch)
+    assert 22 not in grid.ids
+    assert grid.max_id == 21
+
+
+def test_max_id_deepcopy():
+    grid = Grid.from_txt("1 2 20", "2 3 21")
+    copied = deepcopy(grid)
+    assert copied.max_id == grid.max_id
+    assert copied._max_id == grid._max_id

--- a/tests/unit/model/containers/test_base.py
+++ b/tests/unit/model/containers/test_base.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 import pytest
 
 from power_grid_model_ds._core.model.arrays.base.errors import RecordDoesNotExist
+from power_grid_model_ds._core.model.containers._id_tracker import IdTracker
 from power_grid_model_ds._core.model.containers.base import FancyArrayContainer
 from power_grid_model_ds._core.model.grids.base import Grid
 from power_grid_model_ds.arrays import (
@@ -191,8 +192,7 @@ def test_rebuild_ids():
     grid = Grid.from_txt("1 2 20", "2 3 21", "10 11 22")
     expected_ids = {1, 2, 3, 10, 11, 20, 21, 22}
     assert grid.ids == expected_ids
-    grid._ids = set()
-    grid._max_id = 0
+    grid._id_tracker = IdTracker()
     grid.rebuild_ids()
     assert grid.ids == expected_ids
     assert grid.max_id == max(expected_ids)
@@ -213,7 +213,6 @@ def test_ids():
 def test_max_id_empty_container():
     container = FancyArrayContainer.empty()
     assert container.max_id == 0
-    assert container._max_id == 0
 
 
 def test_max_id_after_append_with_explicit_ids():
@@ -222,7 +221,6 @@ def test_max_id_after_append_with_explicit_ids():
     nodes.id = [1, 2, 5]
     grid.append(nodes)
     assert grid.max_id == 5
-    assert grid._max_id == 5
 
 
 def test_max_id_after_append_with_lower_ids():
@@ -238,7 +236,6 @@ def test_max_id_after_append_with_lower_ids():
     lines.to_node = [20, 20]
     grid.append(lines)
     assert grid.max_id == 20
-    assert grid._max_id == 20
 
 
 def test_max_id_after_append_with_higher_ids():
@@ -252,7 +249,6 @@ def test_max_id_after_append_with_higher_ids():
     more_nodes.id = [8, 9]
     grid.append(more_nodes)
     assert grid.max_id == 9
-    assert grid._max_id == 9
 
 
 def test_max_id_after_attach_ids():
@@ -261,13 +257,11 @@ def test_max_id_after_attach_ids():
     grid.append(nodes)  # empty ids -> attach_ids
     assert set(grid.node.id.tolist()) == {1, 2, 3}
     assert grid.max_id == 3
-    assert grid._max_id == 3
 
     more_nodes = NodeArray.zeros(2)
     grid.append(more_nodes)
     assert set(more_nodes.id.tolist()) == {4, 5}
     assert grid.max_id == 5
-    assert grid._max_id == 5
 
 
 def test_max_id_attach_ids_directly():
@@ -289,13 +283,11 @@ def test_max_id_after_rebuild_ids_decreases():
 
     assert grid.ids == {1, 2, 3, 10, 20, 21}
     assert grid.max_id == 21
-    assert grid._max_id == 21
 
 
 def test_max_id_after_rebuild_ids_empty():
     grid = Grid.empty()
-    grid._ids = {99}
-    grid._max_id = 99
+    grid._id_tracker = IdTracker({99})
     grid.rebuild_ids()
     assert grid.ids == set()
     assert grid.max_id == 0
@@ -314,5 +306,5 @@ def test_max_id_after_delete_via_grid_api():
 def test_max_id_deepcopy():
     grid = Grid.from_txt("1 2 20", "2 3 21")
     copied = deepcopy(grid)
+    assert copied.ids == grid.ids
     assert copied.max_id == grid.max_id
-    assert copied._max_id == grid._max_id

--- a/tests/unit/model/containers/test_id_tracker.py
+++ b/tests/unit/model/containers/test_id_tracker.py
@@ -4,8 +4,6 @@
 
 """Tests for IdTracker."""
 
-import pytest
-
 from power_grid_model_ds._core.model.containers._id_tracker import IdTracker
 
 
@@ -55,16 +53,3 @@ def test_add_with_max_new_id():
     tracker.add({2, 3}, max_new_id=100)
     assert tracker.ids == {1, 2, 3}
     assert tracker.max_id == 100
-
-
-@pytest.mark.parametrize(
-    ("tracker_a", "tracker_b", "expected"),
-    [
-        (IdTracker(), IdTracker(), True),
-        (IdTracker({1, 2}), IdTracker({1, 2}), True),
-        (IdTracker({1, 2}), IdTracker({1, 3}), False),
-        (IdTracker({1, 2}), {1, 2}, False),
-    ],
-)
-def test_equality(tracker_a, tracker_b, expected):
-    assert (tracker_a == tracker_b) is expected

--- a/tests/unit/model/containers/test_id_tracker.py
+++ b/tests/unit/model/containers/test_id_tracker.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+"""Tests for IdTracker."""
+
+import pytest
+
+from power_grid_model_ds._core.model.containers._id_tracker import IdTracker
+
+
+def test_empty_init():
+    tracker = IdTracker()
+    assert tracker.ids == set()
+    assert tracker.max_id == 0
+
+
+def test_init_from_set():
+    tracker = IdTracker({1, 5, 3})
+    assert tracker.ids == {1, 3, 5}
+    assert tracker.max_id == 5
+
+
+def test_init_copies_input_set():
+    ids = {1, 2, 3}
+    tracker = IdTracker(ids)
+    ids.add(99)
+    assert tracker.ids == {1, 2, 3}
+    assert tracker.max_id == 3
+
+
+def test_add_higher_ids():
+    tracker = IdTracker({1, 2})
+    tracker.add({5, 7})
+    assert tracker.ids == {1, 2, 5, 7}
+    assert tracker.max_id == 7
+
+
+def test_add_lower_ids():
+    tracker = IdTracker({10, 20})
+    tracker.add({3, 4})
+    assert tracker.ids == {3, 4, 10, 20}
+    assert tracker.max_id == 20
+
+
+def test_add_empty_set():
+    tracker = IdTracker({1, 2})
+    tracker.add(set())
+    assert tracker.ids == {1, 2}
+    assert tracker.max_id == 2
+
+
+def test_add_with_max_new_id():
+    tracker = IdTracker({1})
+    tracker.add({2, 3}, max_new_id=100)
+    assert tracker.ids == {1, 2, 3}
+    assert tracker.max_id == 100
+
+
+@pytest.mark.parametrize(
+    ("tracker_a", "tracker_b", "expected"),
+    [
+        (IdTracker(), IdTracker(), True),
+        (IdTracker({1, 2}), IdTracker({1, 2}), True),
+        (IdTracker({1, 2}), IdTracker({1, 3}), False),
+        (IdTracker({1, 2}), {1, 2}, False),
+    ],
+)
+def test_equality(tracker_a, tracker_b, expected):
+    assert (tracker_a == tracker_b) is expected

--- a/tests/unit/model/grids/test_base.py
+++ b/tests/unit/model/grids/test_base.py
@@ -18,7 +18,7 @@ from tests.fixtures.grids import build_basic_grid
 # pylint: disable=missing-function-docstring,missing-class-docstring
 
 
-@pytest.mark.parametrize("base_attr", ["_ids", "graphs"])
+@pytest.mark.parametrize("base_attr", ["_ids", "_max_id", "graphs"])
 def test_grid_has_base_attributes(base_attr: str):
     grid = Grid.empty()
     assert isinstance(grid, Grid)

--- a/tests/unit/model/grids/test_base.py
+++ b/tests/unit/model/grids/test_base.py
@@ -18,7 +18,7 @@ from tests.fixtures.grids import build_basic_grid
 # pylint: disable=missing-function-docstring,missing-class-docstring
 
 
-@pytest.mark.parametrize("base_attr", ["_ids", "_max_id", "graphs"])
+@pytest.mark.parametrize("base_attr", ["_id_tracker", "graphs"])
 def test_grid_has_base_attributes(base_attr: str):
     grid = Grid.empty()
     assert isinstance(grid, Grid)

--- a/tests/unit/model/grids/test_search.py
+++ b/tests/unit/model/grids/test_search.py
@@ -165,10 +165,11 @@ class TestGridDiff:
         grid2 = Grid.from_txt("1 2 10", "2 3 11", "3 4 12")
 
         diff_dict = find_differences_between_grids(grid1, grid2)
-        assert len(diff_dict) == 4
+        assert len(diff_dict) == 5
         assert "line" in diff_dict
         assert not diff_dict["line"]["grid1"].size
         assert diff_dict["line"]["grid2"].size
+        assert diff_dict["_max_id"] == {"grid1": 11, "grid2": 12}
 
     def test_different_grid_types(self):
         grid1 = Grid.from_txt("1 2 10", "2 4 11")

--- a/tests/unit/model/grids/test_search.py
+++ b/tests/unit/model/grids/test_search.py
@@ -9,6 +9,7 @@ import pytest
 
 from power_grid_model_ds import Grid
 from power_grid_model_ds._core.model.arrays.base.errors import RecordDoesNotExist
+from power_grid_model_ds._core.model.containers._id_tracker import IdTracker
 from power_grid_model_ds._core.model.enums.nodes import NodeType
 from power_grid_model_ds._core.model.grids._search import find_differences_between_grids
 from power_grid_model_ds.arrays import LineArray, LinkArray, NodeArray, TransformerArray
@@ -165,11 +166,14 @@ class TestGridDiff:
         grid2 = Grid.from_txt("1 2 10", "2 3 11", "3 4 12")
 
         diff_dict = find_differences_between_grids(grid1, grid2)
-        assert len(diff_dict) == 5
+        assert len(diff_dict) == 4
         assert "line" in diff_dict
         assert not diff_dict["line"]["grid1"].size
         assert diff_dict["line"]["grid2"].size
-        assert diff_dict["_max_id"] == {"grid1": 11, "grid2": 12}
+        assert diff_dict["_id_tracker"] == {
+            "grid1": IdTracker({1, 2, 3, 10, 11}),
+            "grid2": IdTracker({1, 2, 3, 4, 10, 11, 12}),
+        }
 
     def test_different_grid_types(self):
         grid1 = Grid.from_txt("1 2 10", "2 4 11")
@@ -182,7 +186,7 @@ class TestGridDiff:
         grid2 = Grid.from_txt("1 2 10", "2 4 11")
         grid1.diff(grid2)
         captured = capsys.readouterr()
-        assert "There are differences in 'grid._ids'" in captured.out
+        assert "There are differences in 'grid._id_tracker'" in captured.out
         assert "There are differences in 'grid.graphs'" in captured.out
         assert "There are differences in 'grid.node'" in captured.out
         assert "There are differences in 'grid.line'" in captured.out


### PR DESCRIPTION
Fixes #issue_number

### Changes proposed in this PR includes
Add _max_id as a parameter to the FancyArrayContainer. The ids area already kind of 'stale' in the sense that they're updated only if people use the container correctly. If they change ids on the arrays directly it could still deviate. This max_id is the same. Max_id is now updated as a single int instead of requiring the max(self._ids) calculation. It sounds bizar but due to calling attach_ids a lot this became a major bottleneck in our code. Making it an int we track will help improve performance significantly for us.

### Could you please pay extra attention to the points below when reviewing the PR
If self._ids is updated outside of the FancyArrayContainer (which I think it shouldn't as it's a private variable) that could result in container.max_id to be different than before potentially breaking code. Is this acceptable?

### Checks

- [ nvt ] If changes are related to CI/CD, are they verified via a manual run on this branch?
- [ no ] Do you wish to discuss this PR in the bi monthly community meeting?
Please join the [PGM community meeting](<https://zoom-lfx.platform.linuxfoundation.org/meeting/91445523235?password=e565df23-7c6d-4d67-94e6-f5774cfd4745>)
